### PR TITLE
fix: WB-2582, avoid null pointer on shared posts rights

### DIFF
--- a/backend/src/main/java/org/entcore/blog/security/BlogResourcesProvider.java
+++ b/backend/src/main/java/org/entcore/blog/security/BlogResourcesProvider.java
@@ -244,7 +244,7 @@ public class BlogResourcesProvider implements ResourcesProvider {
 			final boolean hasShareRights = blogObject.getJsonArray("shared").stream().anyMatch(rights -> {
 				JsonObject jsonRights = (JsonObject) rights;
 				return jsonRights.getBoolean(action, false) &&
-						(jsonRights.getString("userId").equals(userId)
+						(userId.equals(jsonRights.getString("userId"))
 								|| userGroups.contains(jsonRights.getString("groupId")));
 			});
 			return isBlogAuthor || hasShareRights;


### PR DESCRIPTION
Corrige une NPE lors de la vérification des droits d'accès à un post partagé