### PR TITLE
feat: #WB-2642, apply previous logic to publish or submit a post

### DIFF
--- a/frontend/src/features/Post/CreatePost.tsx
+++ b/frontend/src/features/Post/CreatePost.tsx
@@ -20,7 +20,7 @@ export const CreatePost = ({ blogId }: CreatePostProps) => {
 
   const navigate = useNavigate();
 
-  const { mustSubmit, defaultPublishAction } = useActionDefinitions([]);
+  const { mustSubmit, getDefaultPublishKeyword } = useActionDefinitions([]);
   const createMutation = useCreatePost(blogId);
   const publishMutation = usePublishPost(blogId);
 
@@ -43,7 +43,10 @@ export const CreatePost = ({ blogId }: CreatePostProps) => {
   const handlePublishClick = async () => {
     const post = await create();
     if (post) {
-      await publishMutation.mutate({ post, publishWith: defaultPublishAction });
+      await publishMutation.mutate({
+        post,
+        publishWith: getDefaultPublishKeyword(post.author.userId),
+      });
       navigate(`/id/${blogId}/post/${post?._id}`);
     }
   };


### PR DESCRIPTION
Ce commit réapplique la logique historique requise côté frontend pour appeler les endpoints de publication/soumission de billet  adéquats côté backend.

Ne pas appliquer cette logique provoquait des régressions (ex: tickets soumis publiés, ou tickets publiés soumis...)