### PR TITLE
fix: WB-2256, apply shared right on comment zone

### DIFF
--- a/frontend/src/config/index.ts
+++ b/frontend/src/config/index.ts
@@ -4,5 +4,4 @@ export const workflows = {
   createPublic: "org.entcore.blog.controllers.BlogController|createPublicBlog",
   publish: "org.entcore.blog.controllers.BlogController|publish",
   print: "org.entcore.blog.controllers.BlogController|print",
-  comment: "org.entcore.blog.controllers.PostController|comment",
 } as const;

--- a/frontend/src/config/postCommentActions.ts
+++ b/frontend/src/config/postCommentActions.ts
@@ -10,6 +10,6 @@ export const postCommentActions: Array<IActionDefinition> = [
   {
     // publish/delete a comment
     id: ACTION.COMMENT,
-    workflow: workflows.comment,
+    workflow: workflows.access,
   },
 ];

--- a/frontend/src/features/ActionBar/useActionDefinitions.ts
+++ b/frontend/src/features/ActionBar/useActionDefinitions.ts
@@ -17,7 +17,8 @@ type SharedRoles = {
   read: boolean;
   contrib: boolean;
   manager: boolean;
-  comment: boolean;
+  canComment: boolean;
+  canContrib: boolean;
 };
 type SharedRight = {
   "org-entcore-blog-controllers-PostController|list": boolean;
@@ -50,7 +51,8 @@ export const useActionDefinitions = (
       read: false,
       contrib: false,
       manager: false,
-      comment: false,
+      canContrib: false,
+      canComment: false,
       hasPublishPostRight: false,
       hasSubmitPostRight: false,
     };
@@ -84,8 +86,11 @@ export const useActionDefinitions = (
             current[
               "org-entcore-blog-controllers-BlogController|shareResource"
             ];
-          previous.comment ||=
+          previous.canComment ||=
             current["org-entcore-blog-controllers-PostController|comment"];
+
+          previous.canContrib ||=
+            author.userId === userId || previous.contrib || previous.manager;
 
           // Also look for the real publish/submit URL to use.
           // If both are acceptable, prefer publish over submit.
@@ -106,11 +111,6 @@ export const useActionDefinitions = (
       creator: author.userId === userId,
     };
   }, [blog, user]);
-
-  const canContrib = useMemo(
-    () => rights.contrib || rights.creator || rights.manager,
-    [rights],
-  );
 
   /**
    * Check the `right` field of an IAction.
@@ -234,6 +234,5 @@ export const useActionDefinitions = (
     getDefaultPublishKeyword,
     availableActionsForPost,
     availableActionsForBlog,
-    canContrib,
   };
 };

--- a/frontend/src/features/ActionBar/useActionDefinitions.ts
+++ b/frontend/src/features/ActionBar/useActionDefinitions.ts
@@ -13,12 +13,18 @@ type SpecialPostRights = {
   hasPublishPostRight: boolean;
   hasSubmitPostRight: boolean;
 };
-type SharedRoles = { read: boolean; contrib: boolean; manager: boolean };
+type SharedRoles = {
+  read: boolean;
+  contrib: boolean;
+  manager: boolean;
+  comment: boolean;
+};
 type SharedRight = {
   "org-entcore-blog-controllers-PostController|list": boolean;
   "org-entcore-blog-controllers-PostController|submit": boolean;
   "org-entcore-blog-controllers-PostController|publish": boolean;
   "org-entcore-blog-controllers-BlogController|shareResource": boolean;
+  "org-entcore-blog-controllers-PostController|comment": boolean;
 };
 
 /**
@@ -44,6 +50,7 @@ export const useActionDefinitions = (
       read: false,
       contrib: false,
       manager: false,
+      comment: false,
       hasPublishPostRight: false,
       hasSubmitPostRight: false,
     };
@@ -77,6 +84,8 @@ export const useActionDefinitions = (
             current[
               "org-entcore-blog-controllers-BlogController|shareResource"
             ];
+          previous.comment ||=
+            current["org-entcore-blog-controllers-PostController|comment"];
 
           // Also look for the real publish/submit URL to use.
           // If both are acceptable, prefer publish over submit.

--- a/frontend/src/features/Comments/CommentsCreate.tsx
+++ b/frontend/src/features/Comments/CommentsCreate.tsx
@@ -15,11 +15,11 @@ export interface CommentsCreateProps {
 export const CommentsCreate = ({ comments }: CommentsCreateProps) => {
   const { user } = useUser();
   const { blogId, postId } = useParams();
-  const { create } = useComments(blogId!, postId!);
+  const { canCreate, create } = useComments(blogId!, postId!);
 
-  if (!user?.userId || !blogId || !postId) return <></>;
+  if (!user?.userId || !blogId || !postId || !canCreate) return <></>;
 
-  const cssClasses = clsx({ "bg-gray-200": comments.length > 0 });
+  const cssClasses = clsx("mt-16", { "bg-gray-200": comments.length > 0 });
 
   const userAsAuthor = {
     userId: user?.userId,

--- a/frontend/src/features/Comments/CommentsHeader.tsx
+++ b/frontend/src/features/Comments/CommentsHeader.tsx
@@ -10,7 +10,7 @@ export const CommentsHeader = ({ comments }: CommentsHeaderProps) => {
   const { t } = useTranslation("blog");
 
   return (
-    <div className="d-flex justify-content-between align-items-center py-24">
+    <div className="d-flex justify-content-between align-items-center pt-24 pb-8">
       <h3>
         {comments.length} {t("blog.comments")}
       </h3>

--- a/frontend/src/features/Comments/CommentsList.tsx
+++ b/frontend/src/features/Comments/CommentsList.tsx
@@ -21,9 +21,12 @@ export const CommentsList = ({ comments }: CommentsListProps) => {
 
   const { t } = useTranslation("blog");
   const { blogId, postId } = useParams();
-  const { canEdit, canRemove, update, remove } = useComments(blogId!, postId!);
+  const { canCreate, canEdit, canRemove, update, remove } = useComments(
+    blogId!,
+    postId!,
+  );
 
-  if (!blogId || !postId) return <></>;
+  if (!blogId || !postId || (!canCreate && comments.length <= 0)) return <></>;
 
   const handlePublishClick = (comment: Comment, newContent: Content) => {
     comment.comment = newContent as string;
@@ -48,7 +51,7 @@ export const CommentsList = ({ comments }: CommentsListProps) => {
           author={comment.author}
           content={comment.comment}
           mode="read"
-          created={comment.created}
+          created={comment.modified ?? comment.created}
           onPublish={
             canEdit(comment)
               ? (newContent) => handlePublishClick(comment, newContent)
@@ -71,7 +74,7 @@ export const CommentsList = ({ comments }: CommentsListProps) => {
       )}
     </>
   ) : (
-    <div className="m-auto">
+    <div className="m-auto mt-24">
       <EmptyScreen
         imageSrc={`${imagePath}/emptyscreen/illu-pad.svg`}
         text={t("blog.comment.emptyscreen.text")}

--- a/frontend/src/hooks/useComments.tsx
+++ b/frontend/src/hooks/useComments.tsx
@@ -1,5 +1,4 @@
 import { useUser } from "@edifice-ui/react";
-import { ACTION } from "edifice-ts-client";
 
 import { useActionDefinitions } from "../features/ActionBar/useActionDefinitions";
 import { postCommentActions } from "~/config/postCommentActions";
@@ -27,20 +26,21 @@ export interface CommentActions {
 
 export const useComments = (blogId: string, postId: string): CommentActions => {
   const { user } = useUser();
-  const { hasRight, manager, comment } =
+  const { creator, manager, canComment } =
     useActionDefinitions(postCommentActions);
 
   const canEdit = (comment: Comment) =>
-    comment.author.userId === user?.userId && hasRight(ACTION.COMMENT);
+    comment.author.userId === user?.userId && canComment;
 
-  const canRemove = (comment: Comment) => manager || canEdit(comment);
+  const canRemove = (comment: Comment) =>
+    creator || manager || canEdit(comment);
 
   const createMutation = useCreateComment(blogId, postId);
   const deleteMutation = useDeleteComment(blogId, postId);
   const updateMutation = useUpdateComment(blogId, postId);
 
   return {
-    canCreate: comment,
+    canCreate: canComment,
     canEdit,
     canRemove,
     create: (content: string) => createMutation.mutate({ content }),

--- a/frontend/src/hooks/useComments.tsx
+++ b/frontend/src/hooks/useComments.tsx
@@ -11,6 +11,8 @@ import {
 } from "~/services/queries";
 
 export interface CommentActions {
+  /** Truthy if the user can create a new comment. */
+  canCreate: boolean;
   /** Truthy if the user can edit (and update) the comment. */
   canEdit: (comment: Comment) => boolean;
   /** Truthy if the user can remove the comment. */
@@ -25,7 +27,8 @@ export interface CommentActions {
 
 export const useComments = (blogId: string, postId: string): CommentActions => {
   const { user } = useUser();
-  const { hasRight, manager } = useActionDefinitions(postCommentActions);
+  const { hasRight, manager, comment } =
+    useActionDefinitions(postCommentActions);
 
   const canEdit = (comment: Comment) =>
     comment.author.userId === user?.userId && hasRight(ACTION.COMMENT);
@@ -37,6 +40,7 @@ export const useComments = (blogId: string, postId: string): CommentActions => {
   const updateMutation = useUpdateComment(blogId, postId);
 
   return {
+    canCreate: comment,
     canEdit,
     canRemove,
     create: (content: string) => createMutation.mutate({ content }),

--- a/frontend/src/models/comment.ts
+++ b/frontend/src/models/comment.ts
@@ -12,6 +12,9 @@ export type Comment = {
   created: {
     $date: number;
   };
+  modified?: {
+    $date: number;
+  };
   author: {
     userId: ID;
     username: string;


### PR DESCRIPTION
* adapt margins to respect designed UI when comments are visible / hidden...
* blog authors can also delete comments (like a manager)
* unified canComment / canContrib computation.