### PR TITLE
fix: WB-2255, new ButtonsGroup component applied

### DIFF
--- a/frontend/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/frontend/src/components/ButtonGroup/ButtonGroup.tsx
@@ -1,16 +1,16 @@
 import clsx from "clsx";
 
-export interface ButtonsGroupProps {
+export interface ButtonGroupProps {
   className?: string;
   children: Array<JSX.Element | false>;
   variant?: "reverse";
 }
 
-export const ButtonsGroup = ({
+export const ButtonGroup = ({
   className,
   variant,
   children,
-}: ButtonsGroupProps) => {
+}: ButtonGroupProps) => {
   const classes = clsx(
     "d-flex flex-fill align-items-center justify-content-end",
     className,

--- a/frontend/src/components/ButtonsGroup/ButtonsGroup.tsx
+++ b/frontend/src/components/ButtonsGroup/ButtonsGroup.tsx
@@ -1,0 +1,22 @@
+import clsx from "clsx";
+
+export interface ButtonsGroupProps {
+  className?: string;
+  children: Array<JSX.Element | false>;
+  variant?: "reverse";
+}
+
+export const ButtonsGroup = ({
+  className,
+  variant,
+  children,
+}: ButtonsGroupProps) => {
+  const classes = clsx(
+    "d-flex flex-fill align-items-center justify-content-end",
+    className,
+    {
+      "align-self-end flex-wrap-reverse": variant === "reverse",
+    },
+  );
+  return <div className={classes}>{children}</div>;
+};

--- a/frontend/src/components/CommentCard/CommentCard.tsx
+++ b/frontend/src/components/CommentCard/CommentCard.tsx
@@ -128,7 +128,7 @@ export const CommentCard = ({
             </div>
           ) : (
             <div className="ms-4">
-              <div className="mb-8 d-flex text-gray-700 small gap-8">
+              <div className="mb-8 d-flex flex-column flex-md-row text-gray-700 small column-gap-12 align-items-md-center">
                 <a
                   href={getUserbookURL(author.userId)}
                   className="comment-card-author"
@@ -138,7 +138,7 @@ export const CommentCard = ({
                 {badge}
                 {created && (
                   <>
-                    <span className="d-none d-md-block mx-4 d-none d-md-block mx-4 border border-top-0 border-end-0 border-bottom-0 border-gray-600"></span>
+                    <span className="separator d-none d-md-block"></span>
                     <span>
                       {t("comment.publish.date", { date: fromNow(created) })}
                     </span>

--- a/frontend/src/components/CommentCard/CommentCard.tsx
+++ b/frontend/src/components/CommentCard/CommentCard.tsx
@@ -7,6 +7,7 @@ import clsx from "clsx";
 import { ID, IUserDescription } from "edifice-ts-client";
 import { useTranslation } from "react-i18next";
 
+import { ButtonsGroup } from "../ButtonsGroup/ButtonsGroup";
 import { getAvatarURL, getUserbookURL } from "~/utils/PostUtils";
 
 const MAX_COMMENT_LENGTH = 800;
@@ -100,7 +101,7 @@ export const CommentCard = ({
               <div>{t("comment.placeholder")}</div>
               <div className="border rounded-3 px-16 pt-12 pb-8 d-flex gap-2 flex-column bg-white">
                 <EditorContent editor={editor}></EditorContent>
-                <div className="d-flex gap-12 justify-content-end align-items-center">
+                <ButtonsGroup className="gap-12" variant="reverse">
                   <span className="small text-gray-700">
                     {commentLength} / {MAX_COMMENT_LENGTH}
                   </span>
@@ -122,7 +123,7 @@ export const CommentCard = ({
                   >
                     {t("comment.post")}
                   </Button>
-                </div>
+                </ButtonsGroup>
               </div>
             </div>
           ) : (

--- a/frontend/src/components/CommentCard/CommentCard.tsx
+++ b/frontend/src/components/CommentCard/CommentCard.tsx
@@ -7,7 +7,7 @@ import clsx from "clsx";
 import { ID, IUserDescription } from "edifice-ts-client";
 import { useTranslation } from "react-i18next";
 
-import { ButtonsGroup } from "../ButtonsGroup/ButtonsGroup";
+import { ButtonGroup } from "../ButtonGroup/ButtonGroup";
 import { getAvatarURL, getUserbookURL } from "~/utils/PostUtils";
 
 const MAX_COMMENT_LENGTH = 800;
@@ -101,7 +101,7 @@ export const CommentCard = ({
               <div>{t("comment.placeholder")}</div>
               <div className="border rounded-3 px-16 pt-12 pb-8 d-flex gap-2 flex-column bg-white">
                 <EditorContent editor={editor}></EditorContent>
-                <ButtonsGroup className="gap-12" variant="reverse">
+                <ButtonGroup className="gap-12" variant="reverse">
                   <span className="small text-gray-700">
                     {commentLength} / {MAX_COMMENT_LENGTH}
                   </span>
@@ -123,7 +123,7 @@ export const CommentCard = ({
                   >
                     {t("comment.post")}
                   </Button>
-                </ButtonsGroup>
+                </ButtonGroup>
               </div>
             </div>
           ) : (

--- a/frontend/src/components/CommentCard/CommentCard.tsx
+++ b/frontend/src/components/CommentCard/CommentCard.tsx
@@ -86,8 +86,12 @@ export const CommentCard = ({
     setEditable(mode === "edit");
   };
 
+  const cssClasses = clsx("border rounded-3 p-12 pb-8 d-flex", className, {
+    "bg-gray-200": mode === "edit",
+  });
+
   return (
-    <div className={clsx("border rounded-3 p-12 pb-8 d-flex", className)}>
+    <div className={cssClasses}>
       <Avatar
         alt={t("comment.author.avatar")}
         size="sm"

--- a/frontend/src/components/PostPreview/PostPreview.tsx
+++ b/frontend/src/components/PostPreview/PostPreview.tsx
@@ -177,7 +177,7 @@ export const PostPreview = ({ post, index }: PostPreviewProps) => {
             </div>
             <div className="text-gray-700 small column-gap-12 d-flex flex-column flex-md-row align-items-md-center">
               <span>{post.author.username}</span>
-              <span className="separator border border-top-0 border-end-0 border-bottom-0 border-gray-600 d-none d-md-inline-block"></span>
+              <span className="separator d-none d-md-inline-block"></span>
               <span>{getDatedState()}</span>
             </div>
           </div>

--- a/frontend/src/features/Blog/BlogActionBar.tsx
+++ b/frontend/src/features/Blog/BlogActionBar.tsx
@@ -7,7 +7,7 @@ import { ACTION, ActionType } from "edifice-ts-client";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
-import { ButtonsGroup } from "~/components/ButtonsGroup/ButtonsGroup";
+import { ButtonGroup } from "~/components/ButtonGroup/ButtonGroup";
 import { ActionBarContainer } from "~/features/ActionBar/ActionBarContainer";
 import { useBlogActions } from "~/features/ActionBar/useBlogActions";
 import { Blog } from "~/models/blog";
@@ -137,7 +137,7 @@ export const BlogActionBar = ({ blog }: BlogActionBarProps) => {
 
   return (
     <>
-      <ButtonsGroup className="gap-12 align-self-end">
+      <ButtonGroup className="gap-12 align-self-end">
         {canContrib && (
           <Button
             leftIcon={<Plus />}
@@ -213,7 +213,7 @@ export const BlogActionBar = ({ blog }: BlogActionBarProps) => {
             <></>
           )}
         </ActionBarContainer>
-      </ButtonsGroup>
+      </ButtonGroup>
 
       <Suspense>
         {isUpdateModalOpen && (

--- a/frontend/src/features/Blog/BlogActionBar.tsx
+++ b/frontend/src/features/Blog/BlogActionBar.tsx
@@ -7,6 +7,7 @@ import { ACTION, ActionType } from "edifice-ts-client";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
+import { ButtonsGroup } from "~/components/ButtonsGroup/ButtonsGroup";
 import { ActionBarContainer } from "~/features/ActionBar/ActionBarContainer";
 import { useBlogActions } from "~/features/ActionBar/useBlogActions";
 import { Blog } from "~/models/blog";
@@ -136,7 +137,7 @@ export const BlogActionBar = ({ blog }: BlogActionBarProps) => {
 
   return (
     <>
-      <div className="d-flex flex-fill align-items-center align-self-end justify-content-end gap-12">
+      <ButtonsGroup className="gap-12 align-self-end">
         {canContrib && (
           <Button
             leftIcon={<Plus />}
@@ -212,7 +213,7 @@ export const BlogActionBar = ({ blog }: BlogActionBarProps) => {
             <></>
           )}
         </ActionBarContainer>
-      </div>
+      </ButtonsGroup>
 
       <Suspense>
         {isUpdateModalOpen && (

--- a/frontend/src/features/Comments/CommentsCreate.tsx
+++ b/frontend/src/features/Comments/CommentsCreate.tsx
@@ -1,25 +1,17 @@
 import { Content } from "@edifice-ui/editor";
 import { useUser } from "@edifice-ui/react";
-import clsx from "clsx";
 import { UserProfile } from "edifice-ts-client";
 import { useParams } from "react-router-dom";
 
 import { CommentCard } from "~/components/CommentCard/CommentCard";
 import { useComments } from "~/hooks/useComments";
-import { Comment } from "~/models/comment";
 
-export interface CommentsCreateProps {
-  comments: Comment[];
-}
-
-export const CommentsCreate = ({ comments }: CommentsCreateProps) => {
+export const CommentsCreate = () => {
   const { user } = useUser();
   const { blogId, postId } = useParams();
   const { canCreate, create } = useComments(blogId!, postId!);
 
   if (!user?.userId || !blogId || !postId || !canCreate) return <></>;
-
-  const cssClasses = clsx("mt-16", { "bg-gray-200": comments.length > 0 });
 
   const userAsAuthor = {
     userId: user?.userId,
@@ -33,7 +25,7 @@ export const CommentsCreate = ({ comments }: CommentsCreateProps) => {
 
   return (
     <CommentCard
-      className={cssClasses}
+      className="mt-16"
       author={userAsAuthor}
       mode="edit"
       onPublish={handlePublish}

--- a/frontend/src/features/Post/CreatePost.tsx
+++ b/frontend/src/features/Post/CreatePost.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
 import { useActionDefinitions } from "../ActionBar/useActionDefinitions";
-import { ButtonsGroup } from "~/components/ButtonsGroup/ButtonsGroup";
+import { ButtonGroup } from "~/components/ButtonGroup/ButtonGroup";
 import { useCreatePost, usePublishPost } from "~/services/queries";
 
 export interface CreatePostProps {
@@ -69,7 +69,7 @@ export const CreatePost = ({ blogId }: CreatePostProps) => {
       <div className="mx-md-16">
         <Editor ref={editorRef} content="" mode="edit"></Editor>
       </div>
-      <ButtonsGroup className="gap-8 mt-16 mx-md-16" variant="reverse">
+      <ButtonGroup className="gap-8 mt-16 mx-md-16" variant="reverse">
         <Button type="button" variant="ghost" onClick={handleCancelClick}>
           {t("cancel")}
         </Button>
@@ -84,7 +84,7 @@ export const CreatePost = ({ blogId }: CreatePostProps) => {
         <Button type="button" leftIcon={<Send />} onClick={handlePublishClick}>
           {mustSubmit ? t("blog.submitPost") : t("blog.publish")}
         </Button>
-      </ButtonsGroup>
+      </ButtonGroup>
     </div>
   );
 };

--- a/frontend/src/features/Post/CreatePost.tsx
+++ b/frontend/src/features/Post/CreatePost.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
 import { useActionDefinitions } from "../ActionBar/useActionDefinitions";
+import { ButtonsGroup } from "~/components/ButtonsGroup/ButtonsGroup";
 import { useCreatePost, usePublishPost } from "~/services/queries";
 
 export interface CreatePostProps {
@@ -68,7 +69,7 @@ export const CreatePost = ({ blogId }: CreatePostProps) => {
       <div className="mx-md-16">
         <Editor ref={editorRef} content="" mode="edit"></Editor>
       </div>
-      <div className="d-flex gap-8 justify-content-end mt-16 mx-md-16">
+      <ButtonsGroup className="gap-8 mt-16 mx-md-16" variant="reverse">
         <Button type="button" variant="ghost" onClick={handleCancelClick}>
           {t("cancel")}
         </Button>
@@ -83,7 +84,7 @@ export const CreatePost = ({ blogId }: CreatePostProps) => {
         <Button type="button" leftIcon={<Send />} onClick={handlePublishClick}>
           {mustSubmit ? t("blog.submitPost") : t("blog.publish")}
         </Button>
-      </div>
+      </ButtonsGroup>
     </div>
   );
 };

--- a/frontend/src/features/Post/PostContent.tsx
+++ b/frontend/src/features/Post/PostContent.tsx
@@ -190,7 +190,7 @@ export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
       {mode === "read" && (
         <div className="mx-md-8 mt-24">
           <CommentsHeader comments={comments ?? []} />
-          <CommentsCreate comments={comments ?? []} />
+          <CommentsCreate />
           <CommentsList comments={comments ?? []} />
         </div>
       )}

--- a/frontend/src/features/Post/PostContent.tsx
+++ b/frontend/src/features/Post/PostContent.tsx
@@ -11,6 +11,7 @@ import { usePostActions } from "../ActionBar/usePostActions";
 import { CommentsCreate } from "../Comments/CommentsCreate";
 import { CommentsHeader } from "../Comments/CommentsHeader";
 import { CommentsList } from "../Comments/CommentsList";
+import { ButtonsGroup } from "~/components/ButtonsGroup/ButtonsGroup";
 import OldFormatModal from "~/components/OldFormatModal/OldFormatModal";
 import { postContentActions } from "~/config/postContentActions";
 import { Comment } from "~/models/comment";
@@ -59,7 +60,7 @@ export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
   // Handlers for actions triggered from the post title component.
   const postActionsHandlers = {
     onBackward: () => {
-      navigate(-1);
+      navigate(`../..`, { relative: "path" });
     },
     onDelete: () => {
       trash();
@@ -160,7 +161,10 @@ export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
           variant={variant}
         ></Editor>
         {mode === "edit" && (
-          <div className="d-flex gap-8 justify-content-end my-8 sticky-bottom py-8 bg-white">
+          <ButtonsGroup
+            className="gap-8 my-8 sticky-bottom py-8 bg-white"
+            variant="reverse"
+          >
             <Button type="button" variant="ghost" onClick={handleCancelClick}>
               {t("cancel")}
             </Button>
@@ -179,7 +183,7 @@ export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
             >
               {mustSubmit ? t("blog.submitPost") : t("blog.publish")}
             </Button>
-          </div>
+          </ButtonsGroup>
         )}
       </div>
 

--- a/frontend/src/features/Post/PostContent.tsx
+++ b/frontend/src/features/Post/PostContent.tsx
@@ -11,7 +11,7 @@ import { usePostActions } from "../ActionBar/usePostActions";
 import { CommentsCreate } from "../Comments/CommentsCreate";
 import { CommentsHeader } from "../Comments/CommentsHeader";
 import { CommentsList } from "../Comments/CommentsList";
-import { ButtonsGroup } from "~/components/ButtonsGroup/ButtonsGroup";
+import { ButtonGroup } from "~/components/ButtonGroup/ButtonGroup";
 import OldFormatModal from "~/components/OldFormatModal/OldFormatModal";
 import { postContentActions } from "~/config/postContentActions";
 import { Comment } from "~/models/comment";
@@ -161,7 +161,7 @@ export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
           variant={variant}
         ></Editor>
         {mode === "edit" && (
-          <ButtonsGroup
+          <ButtonGroup
             className="gap-8 my-8 sticky-bottom py-8 bg-white"
             variant="reverse"
           >
@@ -183,7 +183,7 @@ export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
             >
               {mustSubmit ? t("blog.submitPost") : t("blog.publish")}
             </Button>
-          </ButtonsGroup>
+          </ButtonGroup>
         )}
       </div>
 

--- a/frontend/src/features/Post/PostTitle.tsx
+++ b/frontend/src/features/Post/PostTitle.tsx
@@ -150,14 +150,14 @@ export const PostTitle = ({
             src={getAvatarURL(post.author.userId)}
             variant="circle"
           />
-          <div className="text-gray-700 small d-flex flex-column flex-md-row gap-12 align-items-md-center ">
+          <div className="text-gray-700 small d-flex flex-column flex-md-row column-gap-12 align-items-md-center ">
             <a
               href={getUserbookURL(post.author.userId)}
               className="comment-card-author"
             >
               {post.author.username}
             </a>
-            <span className="separator border border-top-0 border-end-0 border-bottom-0 border-gray-600"></span>
+            <span className="separator d-none d-md-block"></span>
             <span>{getDatedState(post)}</span>
           </div>
         </div>

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -104,4 +104,6 @@ main {
 
 .separator {
   height: 16px;
+  border: 0;
+  border-left: 1px solid var(--edifice-gray-700);
 }


### PR DESCRIPTION
Suite à évo du design system, j'ai factorisé du code redondant dans un nouveau composant.
Reste à voir si on l'extrait dans edifice-ui ensuite.

Le fix contient aussi 
* une correction de la navigation liée au bouton Retour depuis un post (comme spécifié dans la fonc fonctionnelle)
* des retours UX sur la CommentCard
* des retours UI sur les séparateurs (la classe CSS border-gray-600... n'existait pas !)