### PR TITLE
feat: WB-2688, public blog views

### DIFF
--- a/backend/src/main/java/org/entcore/blog/controllers/BlogController.java
+++ b/backend/src/main/java/org/entcore/blog/controllers/BlogController.java
@@ -601,24 +601,16 @@ public class BlogController extends BaseController {
 	}
 
 	// Routes for public blogs
-	@Get("/pub/print/:blog")
-	public void printPublic(HttpServerRequest request) {
-		String blogId = request.params().get("blog");
-		blog.isPublicBlog(blogId, BlogService.IdType.Id, ev->{
-			if(ev){
-				JsonObject context = new JsonObject().put("printBlogId", blogId);
-				blog.getPublic(blogId, BlogService.IdType.Id, json -> {
-					if (json.isLeft()) {
-						badRequest(request);
-						return;
-					}
-					JsonObject blog = json.right().getValue();
-					renderView(request, context.put("public", true).put("blog",blog).put("blogStr",blog.toString()), "print.html", null);
-				});
-			}else{
-				unauthorized(request);
-			}
-		});
+	@Get("/pub/:slug/print")
+	public void printPublicBlog(HttpServerRequest request) {
+		// Display react front page
+		renderView(request, new JsonObject(), "index.html", null);
+	}
+
+	@Get("/pub/:slug/print/post/:postid")
+	public void printPublicPost(HttpServerRequest request) {
+		// Display react front page
+		renderView(request, new JsonObject(), "index.html", null);
 	}
 
 	@Get("/pub/:slug")

--- a/frontend/src/components/PostPreview/PostPreview.tsx
+++ b/frontend/src/components/PostPreview/PostPreview.tsx
@@ -32,9 +32,13 @@ export type PostPreviewProps = {
    * Index of the post in the list
    */
   index: number;
+  /**
+   * Truthy when the post is public.
+   */
+  isPublic?: boolean;
 };
 
-export const PostPreview = ({ post, index }: PostPreviewProps) => {
+export const PostPreview = ({ post, index, isPublic }: PostPreviewProps) => {
   const { fromNow } = useDate();
   const { t } = useTranslation("blog");
   const navigate = useNavigate();
@@ -42,8 +46,7 @@ export const PostPreview = ({ post, index }: PostPreviewProps) => {
   const { blog } = useBlog();
   const { contrib, manager, creator } = useActionDefinitions([]);
   const { setActionBarPostId } = useStoreUpdaters();
-  const { sidebarHighlightedPost } = useBlogState();
-  const { actionBarPostId } = useBlogState();
+  const { sidebarHighlightedPost, actionBarPostId } = useBlogState();
 
   const editorRef = useRef<EditorRef>(null);
   const cardRef = useRef<HTMLDivElement>(null);
@@ -232,10 +235,12 @@ export const PostPreview = ({ post, index }: PostPreviewProps) => {
             </div>
             <div className="d-flex justify-content-between">
               <div className="d-flex gap-12 small text-gray-700 align-items-center ">
-                <div className="d-flex align-items-center gap-8">
-                  <span>{post.nbComments}</span>
-                  <MessageInfo />
-                </div>
+                {typeof post.nbComments === "number" && (
+                  <div className="d-flex align-items-center gap-8">
+                    <span>{post.nbComments}</span>
+                    <MessageInfo />
+                  </div>
+                )}
               </div>
               <div>
                 <Button
@@ -255,6 +260,7 @@ export const PostPreview = ({ post, index }: PostPreviewProps) => {
           post={post}
           blog={blog}
           index={index}
+          isPublic={isPublic}
         ></PostPreviewActionBar>
       )}
     </>

--- a/frontend/src/components/PostPreview/PostPreview.tsx
+++ b/frontend/src/components/PostPreview/PostPreview.tsx
@@ -32,13 +32,9 @@ export type PostPreviewProps = {
    * Index of the post in the list
    */
   index: number;
-  /**
-   * Truthy when the post is public.
-   */
-  isPublic?: boolean;
 };
 
-export const PostPreview = ({ post, index, isPublic }: PostPreviewProps) => {
+export const PostPreview = ({ post, index }: PostPreviewProps) => {
   const { fromNow } = useDate();
   const { t } = useTranslation("blog");
   const navigate = useNavigate();
@@ -260,7 +256,6 @@ export const PostPreview = ({ post, index, isPublic }: PostPreviewProps) => {
           post={post}
           blog={blog}
           index={index}
-          isPublic={isPublic}
         ></PostPreviewActionBar>
       )}
     </>

--- a/frontend/src/components/PostPreview/PostPreviewActionBar.tsx
+++ b/frontend/src/components/PostPreview/PostPreviewActionBar.tsx
@@ -30,12 +30,17 @@ export interface PostPreviewActionBarProps {
    * Index of the post in the list of posts.
    */
   index: number;
+  /**
+   * Truthy when the post is public.
+   */
+  isPublic?: boolean;
 }
 
 export const PostPreviewActionBar = ({
   blog: blog,
   post,
   index,
+  isPublic,
 }: PostPreviewActionBarProps) => {
   // Get available actions and requirements for the post.
   const postActions = usePostActions(postContentActions, blog._id, post);
@@ -81,30 +86,24 @@ export const PostPreviewActionBar = ({
   return (
     <>
       <ActionBarContainer visible={actionBarPostId === post._id}>
-        {isActionAvailable(ACTION.OPEN) ? (
+        {isActionAvailable(ACTION.OPEN) && (
           <Button type="button" variant="filled" onClick={handleEditClick}>
             {t("blog.edit.post")}
           </Button>
-        ) : (
-          <></>
         )}
         {post.state !== PostState.PUBLISHED &&
-        isActionAvailable(ACTION.PUBLISH) ? (
-          <Button type="button" variant="filled" onClick={handlePublishClick}>
-            {mustSubmit ? t("blog.submitPost") : t("blog.publish")}
-          </Button>
-        ) : (
-          <></>
-        )}
+          isActionAvailable(ACTION.PUBLISH) && (
+            <Button type="button" variant="filled" onClick={handlePublishClick}>
+              {mustSubmit ? t("blog.submitPost") : t("blog.publish")}
+            </Button>
+          )}
         {post.state === PostState.PUBLISHED &&
-        isActionAvailable(ACTION.MOVE) &&
-        index > 0 ? (
-          <Button type="button" variant="filled" onClick={goUp}>
-            {t("goUp")}
-          </Button>
-        ) : (
-          <></>
-        )}
+          isActionAvailable(ACTION.MOVE) &&
+          index > 0 && (
+            <Button type="button" variant="filled" onClick={goUp}>
+              {t("goUp")}
+            </Button>
+          )}
         <Button
           type="button"
           color="primary"
@@ -113,14 +112,16 @@ export const PostPreviewActionBar = ({
         >
           {t("blog.print")}
         </Button>
-        <Button
-          type="button"
-          color="primary"
-          variant="filled"
-          onClick={() => toogleDeleteModalOpen(true)}
-        >
-          {t("blog.delete.post")}
-        </Button>
+        {!isPublic && (
+          <Button
+            type="button"
+            color="primary"
+            variant="filled"
+            onClick={() => toogleDeleteModalOpen(true)}
+          >
+            {t("blog.delete.post")}
+          </Button>
+        )}
       </ActionBarContainer>
 
       <Suspense>

--- a/frontend/src/components/PostPreview/PostPreviewActionBar.tsx
+++ b/frontend/src/components/PostPreview/PostPreviewActionBar.tsx
@@ -30,20 +30,15 @@ export interface PostPreviewActionBarProps {
    * Index of the post in the list of posts.
    */
   index: number;
-  /**
-   * Truthy when the post is public.
-   */
-  isPublic?: boolean;
 }
 
 export const PostPreviewActionBar = ({
-  blog: blog,
+  blog: { _id: blogId, slug, visibility },
   post,
   index,
-  isPublic,
 }: PostPreviewActionBarProps) => {
   // Get available actions and requirements for the post.
-  const postActions = usePostActions(postContentActions, blog._id, post);
+  const postActions = usePostActions(postContentActions, blogId, post);
   const { mustSubmit, isActionAvailable, goUp, publish, trash } = postActions;
 
   const { t } = useTranslation("blog");
@@ -54,18 +49,17 @@ export const PostPreviewActionBar = ({
   const { setActionBarPostId } = useStoreUpdaters();
   const { actionBarPostId } = useBlogState();
 
+  const isPublic = visibility === "PUBLIC";
+
   const handleEditClick = () => {
-    navigate(`/id/${blog._id}/post/${post._id}?edit=true`);
+    navigate(`/id/${blogId}/post/${post._id}?edit=true`);
   };
 
   const handlePrintClick = () => {
-    if (blog.visibility === "PUBLIC") {
-      window.open(
-        `${baseUrl}/pub/print/${blog._id}/post/${post._id}`,
-        "_blank",
-      );
+    if (isPublic) {
+      window.open(`${baseUrl}/pub/${slug}/print/post/${post._id}`, "_blank");
     } else {
-      window.open(`${baseUrl}/print/${blog._id}/post/${post._id}`, "_blank");
+      window.open(`${baseUrl}/print/${blogId}/post/${post._id}`, "_blank");
     }
   };
 

--- a/frontend/src/features/ActionBar/ActionBarContainer.tsx
+++ b/frontend/src/features/ActionBar/ActionBarContainer.tsx
@@ -3,7 +3,7 @@ import { useTransition, animated } from "@react-spring/web";
 
 export interface ActionBarContainerProps {
   visible: boolean;
-  children: JSX.Element[];
+  children: Array<JSX.Element | false>;
 }
 
 export const ActionBarContainer = ({

--- a/frontend/src/features/ActionBar/useActionDefinitions.ts
+++ b/frontend/src/features/ActionBar/useActionDefinitions.ts
@@ -45,6 +45,7 @@ export const useActionDefinitions = (
   // Check resource rights.
   const { user } = useUser();
   const { blog } = useBlog();
+
   const rights = useMemo(() => {
     const defaultRights = {
       creator: false,
@@ -62,8 +63,7 @@ export const useActionDefinitions = (
     }
 
     const { shared, author } = blog;
-    const { userId, groupsIds } = user;
-    const isAuthor = author.userId === userId;
+    const isAuthor = author.userId === user?.userId;
 
     // Look for granted rights in the "shared" array.
     const sharedRights = (shared as any).reduce(
@@ -76,7 +76,8 @@ export const useActionDefinitions = (
       ) => {
         if (
           current &&
-          (current.userId === userId || groupsIds.indexOf(current.groupId) >= 0)
+          (current.userId === user?.userId ||
+            user?.groupsIds.indexOf(current.groupId) >= 0)
         ) {
           previous.read ||=
             current["org-entcore-blog-controllers-PostController|list"];
@@ -91,7 +92,9 @@ export const useActionDefinitions = (
             current["org-entcore-blog-controllers-PostController|comment"];
 
           previous.canContrib ||=
-            author.userId === userId || previous.contrib || previous.manager;
+            author.userId === user?.userId ||
+            previous.contrib ||
+            previous.manager;
 
           // Also look for the real publish/submit URL to use.
           // If both are acceptable, prefer publish over submit.

--- a/frontend/src/features/Blog/BlogActionBar.tsx
+++ b/frontend/src/features/Blog/BlogActionBar.tsx
@@ -128,7 +128,12 @@ export const BlogActionBar = ({ blog }: BlogActionBarProps) => {
   };
 
   const handlePrintClick = () => {
-    window.open(`${baseUrl}/print/${blog._id}`, "_blank");
+    if (blog.slug) {
+      // Public print
+      window.open(`${baseUrl}/pub/${blog.slug}/print`, "_blank");
+    } else {
+      window.open(`${baseUrl}/print/${blog._id}`, "_blank");
+    }
   };
 
   function isActionAvailable(action: ActionType) {

--- a/frontend/src/features/Blog/BlogPostList.tsx
+++ b/frontend/src/features/Blog/BlogPostList.tsx
@@ -10,7 +10,12 @@ import { PostState } from "~/models/post";
 import { useBlogCounter, usePostsList } from "~/services/queries";
 import { useBlogState } from "~/store";
 
-const BlogPostList = () => {
+export interface BlogPostListProps {
+  blogId?: string;
+  isPublic?: boolean;
+}
+
+const BlogPostList = ({ blogId, isPublic }: BlogPostListProps) => {
   const { t } = useTranslation("blog");
   const [imagePath] = usePaths();
 
@@ -18,9 +23,15 @@ const BlogPostList = () => {
   const {
     posts,
     query: { hasNextPage, isFetching, fetchNextPage },
-  } = usePostsList();
+  } = usePostsList(
+    blogId,
+    isPublic ? PostState.PUBLISHED : undefined,
+    isPublic ? false : undefined,
+    isPublic ? true : undefined,
+  );
+
   const { postsFilters } = usePostsFilter();
-  const { counters } = useBlogCounter();
+  const { counters } = useBlogCounter(blogId);
 
   const { sidebarHighlightedPost } = useBlogState();
 
@@ -76,7 +87,12 @@ const BlogPostList = () => {
         </div>
       )}
       {posts?.map((post, index) => (
-        <PostPreview key={post._id} post={post} index={index} />
+        <PostPreview
+          key={post._id}
+          post={post}
+          index={index}
+          isPublic={isPublic}
+        />
       ))}
       {hasNextPage && (
         <div className="d-flex justify-content-center">

--- a/frontend/src/features/Blog/BlogPostList.tsx
+++ b/frontend/src/features/Blog/BlogPostList.tsx
@@ -87,12 +87,7 @@ const BlogPostList = ({ blogId, isPublic }: BlogPostListProps) => {
         </div>
       )}
       {posts?.map((post, index) => (
-        <PostPreview
-          key={post._id}
-          post={post}
-          index={index}
-          isPublic={isPublic}
-        />
+        <PostPreview key={post._id} post={post} index={index} />
       ))}
       {hasNextPage && (
         <div className="d-flex justify-content-center">

--- a/frontend/src/features/Blog/BlogSidebar.tsx
+++ b/frontend/src/features/Blog/BlogSidebar.tsx
@@ -9,18 +9,21 @@ import { useStoreUpdaters } from "~/store";
 
 export interface BlogSidebarProps {
   state?: PostState;
-  isPublic?: boolean;
 }
 
-const BlogSidebar = ({ state, isPublic }: BlogSidebarProps) => {
+const BlogSidebar = ({ state }: BlogSidebarProps) => {
   const { t } = useTranslation("blog");
 
   const { blog } = useBlog();
+
+  const isPublic = blog?.visibility === "PUBLIC";
   const {
     posts,
     query: { hasNextPage, isFetching, fetchNextPage },
   } = usePostsList(blog?._id, state, undefined, isPublic);
+
   const { currentApp } = useOdeClient();
+
   const { setSidebarHighlightedPost } = useStoreUpdaters();
 
   const handleOnClick = (id: string) => {

--- a/frontend/src/features/Blog/BlogSidebar.tsx
+++ b/frontend/src/features/Blog/BlogSidebar.tsx
@@ -9,16 +9,17 @@ import { useStoreUpdaters } from "~/store";
 
 export interface BlogSidebarProps {
   state?: PostState;
+  isPublic?: boolean;
 }
 
-const BlogSidebar = ({ state }: BlogSidebarProps) => {
+const BlogSidebar = ({ state, isPublic }: BlogSidebarProps) => {
   const { t } = useTranslation("blog");
 
   const { blog } = useBlog();
   const {
     posts,
     query: { hasNextPage, isFetching, fetchNextPage },
-  } = usePostsList(blog?._id, state);
+  } = usePostsList(blog?._id, state, undefined, isPublic);
   const { currentApp } = useOdeClient();
   const { setSidebarHighlightedPost } = useStoreUpdaters();
 

--- a/frontend/src/features/Post/PostContent.tsx
+++ b/frontend/src/features/Post/PostContent.tsx
@@ -17,6 +17,7 @@ import { postContentActions } from "~/config/postContentActions";
 import { Comment } from "~/models/comment";
 import { Post } from "~/models/post";
 import { baseUrl } from "~/routes";
+import { useBlog } from "~/services/queries";
 
 export interface PostContentProps {
   post: Post;
@@ -25,6 +26,7 @@ export interface PostContentProps {
 }
 
 export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
+  const { blog } = useBlog();
   // Get available actions and requirements for the post.
   const postActions = usePostActions(postContentActions, blogId, post);
   const { mustSubmit, save, trash, publish, readOnly } = postActions;
@@ -57,6 +59,8 @@ export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode]);
 
+  const { slug, visibility } = blog!;
+
   // Handlers for actions triggered from the post title component.
   const postActionsHandlers = {
     onBackward: () => {
@@ -69,8 +73,13 @@ export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
     onEdit: () => {
       setMode("edit");
     },
-    onPrint: () =>
-      window.open(`${baseUrl}/print/${blogId}/post/${post._id}`, "_blank"),
+    onPrint: () => {
+      if (visibility === "PUBLIC") {
+        window.open(`${baseUrl}/pub/${slug}/print/post/${post._id}`, "_blank");
+      } else {
+        window.open(`${baseUrl}/print/${blogId}/post/${post._id}`, "_blank");
+      }
+    },
     onPublish: () => {
       publish();
     },

--- a/frontend/src/features/Post/PostContent.tsx
+++ b/frontend/src/features/Post/PostContent.tsx
@@ -187,11 +187,11 @@ export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
         )}
       </div>
 
-      {mode === "read" && (
+      {mode === "read" && !!comments && (
         <div className="mx-md-8 mt-24">
-          <CommentsHeader comments={comments ?? []} />
+          <CommentsHeader comments={comments} />
           <CommentsCreate />
-          <CommentsList comments={comments ?? []} />
+          <CommentsList comments={comments} />
         </div>
       )}
       <Suspense>

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -107,11 +107,31 @@ const routes = (queryClient: QueryClient): RouteObject[] => [
           };
         },
       },
+      // This page prints a public blog.
+      {
+        path: "print",
+        async lazy() {
+          const { Component } = await import("~/routes/public-blog-print");
+          return {
+            Component,
+          };
+        },
+      },
       // This page displays an existing post from a public blog.
       {
         path: "post/:postId",
         async lazy() {
           const { Component } = await import("~/routes/public-post");
+          return {
+            Component,
+          };
+        },
+      },
+      // This page prints an existing post from a public blog.
+      {
+        path: "print/post/:postId",
+        async lazy() {
+          const { Component } = await import("~/routes/public-post-print");
           return {
             Component,
           };

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -3,6 +3,7 @@ import { RouteObject, createBrowserRouter } from "react-router-dom";
 
 import { ExplorerBlog } from "./explorer-blog";
 import PageError from "./page-error";
+import PublicPageError from "./public-page-error";
 import { Root } from "~/routes/root";
 
 const routes = (queryClient: QueryClient): RouteObject[] => [
@@ -84,17 +85,40 @@ const routes = (queryClient: QueryClient): RouteObject[] => [
       };
     },
   },
-  // This page displays a public blog.
+  // This page displays a public headless "portal", and preloads blog data.
   {
+    id: "public-portal",
     path: "/pub/:slug",
     async lazy() {
-      const { Component, loader } = await import("~/routes/blog-public");
+      const { Component, loader } = await import("~/routes/public-portal");
       return {
         loader: loader(queryClient),
         Component,
       };
     },
-    errorElement: <PageError />,
+    children: [
+      // This page displays a public blog.
+      {
+        path: "",
+        async lazy() {
+          const { Component } = await import("~/routes/public-blog");
+          return {
+            Component,
+          };
+        },
+      },
+      // This page displays an existing post from a public blog.
+      {
+        path: "post/:postId",
+        async lazy() {
+          const { Component } = await import("~/routes/public-post");
+          return {
+            Component,
+          };
+        },
+      },
+    ],
+    errorElement: <PublicPageError />,
   },
   // This page displays an existing post from a blog.
   {

--- a/frontend/src/routes/page-error/index.tsx
+++ b/frontend/src/routes/page-error/index.tsx
@@ -1,6 +1,6 @@
 import { Button, EmptyScreen, Layout, usePaths } from "@edifice-ui/react";
 import { useTranslation } from "react-i18next";
-import { useRouteError } from "react-router-dom";
+import { useNavigate, useRouteError } from "react-router-dom";
 
 export default function PageError() {
   const error = useRouteError();
@@ -9,6 +9,9 @@ export default function PageError() {
   const { t } = useTranslation();
 
   const [imagePath] = usePaths();
+
+  const navigate = useNavigate();
+  const handleBackClick = () => navigate(-1);
 
   return (
     <Layout>
@@ -21,12 +24,7 @@ export default function PageError() {
             ns: "blog",
           })}
         />
-        <Button
-          color="primary"
-          onClick={() => {
-            window.location.href = "/blog";
-          }}
-        >
+        <Button color="primary" onClick={handleBackClick}>
           {t("back")}
         </Button>
       </div>

--- a/frontend/src/routes/post/index.tsx
+++ b/frontend/src/routes/post/index.tsx
@@ -46,7 +46,11 @@ export function Component() {
   return (
     <>
       <PostHeader />
-      <PostContent blogId={blogId} post={query.data} comments={comments} />
+      <PostContent
+        blogId={blogId}
+        post={query.data}
+        comments={comments ?? []}
+      />
     </>
   );
 }

--- a/frontend/src/routes/public-blog-print/index.tsx
+++ b/frontend/src/routes/public-blog-print/index.tsx
@@ -1,0 +1,56 @@
+import { useEffect } from "react";
+
+import { Editor } from "@edifice-ui/editor";
+import { LoadingScreen } from "@edifice-ui/react";
+
+import { BlogHeader } from "~/features/Blog/BlogHeader";
+import { PostTitle } from "~/features/Post/PostTitle";
+import { PostState } from "~/models/post";
+import { useBlog, usePostsList } from "~/services/queries";
+
+export function Component() {
+  const { blog } = useBlog();
+
+  const {
+    posts,
+    query: { fetchNextPage, hasNextPage, isSuccess, data },
+  } = usePostsList(blog?._id, PostState.PUBLISHED, false, true);
+
+  useEffect(() => {
+    // Load all posts with recurcive fetchNextPage calls.
+    if (isSuccess) {
+      if (hasNextPage) {
+        fetchNextPage();
+      } else {
+        window.print();
+      }
+    }
+  }, [hasNextPage, isSuccess, fetchNextPage, data]);
+
+  if (!blog) return <LoadingScreen />;
+
+  return (
+    <>
+      <div className="px-16">
+        <BlogHeader blog={blog} print={true} />
+      </div>
+      {!isSuccess && hasNextPage && <LoadingScreen />}
+      <div className="d-flex flex-fill bg-white">
+        <div className="flex-fill py-16 ps-16 d-flex flex-column gap-16">
+          {posts.map((post) => (
+            <div key={post._id} className="rounded border pt-16">
+              <PostTitle post={post} mode="print" />
+              <div className="mx-32">
+                <Editor
+                  content={post.content}
+                  mode="read"
+                  variant="ghost"
+                ></Editor>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/routes/public-blog/index.tsx
+++ b/frontend/src/routes/public-blog/index.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 
 import { LoadingScreen } from "@edifice-ui/react";
 
+import { BlogHeader } from "~/features/Blog/BlogHeader";
 import BlogPostList from "~/features/Blog/BlogPostList";
 import BlogSidebar from "~/features/Blog/BlogSidebar";
 import { PostState } from "~/models/post";
@@ -39,11 +40,14 @@ export function Component() {
   if (!blog) return <LoadingScreen />;
 
   return (
-    <div className="d-flex flex-fill">
-      <BlogSidebar isPublic={true} />
-      <div className="flex-fill py-16 ps-md-16 d-flex flex-column">
-        <BlogPostList blogId={blog?._id} isPublic={true} />
+    <main className="container-fluid d-flex flex-column bg-white">
+      <BlogHeader blog={blog} />
+      <div className="d-flex flex-fill">
+        <BlogSidebar />
+        <div className="flex-fill py-16 ps-md-16 d-flex flex-column">
+          <BlogPostList blogId={blog?._id} isPublic={true} />
+        </div>
       </div>
-    </div>
+    </main>
   );
 }

--- a/frontend/src/routes/public-blog/index.tsx
+++ b/frontend/src/routes/public-blog/index.tsx
@@ -1,0 +1,49 @@
+import { useEffect } from "react";
+
+import { LoadingScreen } from "@edifice-ui/react";
+
+import BlogPostList from "~/features/Blog/BlogPostList";
+import BlogSidebar from "~/features/Blog/BlogSidebar";
+import { PostState } from "~/models/post";
+import { useBlog, usePostsList } from "~/services/queries";
+import { useStoreUpdaters } from "~/store";
+
+// loader : See the public-portal loader
+
+export function Component() {
+  const { blog } = useBlog();
+  const { setPostPageSize } = useStoreUpdaters();
+  // Load all posts with recurcive fetchNextPage calls.
+  const {
+    query: { fetchNextPage, hasNextPage, isSuccess, data },
+  } = usePostsList(blog?._id, PostState.PUBLISHED, false, true);
+
+  useEffect(() => {
+    // Check if the second page of post is not null to set the page size. (not given by the backend)
+    if (hasNextPage && data?.pageParams.includes(1) && data?.pages[0]) {
+      setPostPageSize(data?.pages[0].length);
+    }
+
+    // Load at least the 2 first pages of posts to display the page.
+    if (
+      isSuccess &&
+      hasNextPage &&
+      data?.pageParams?.length &&
+      data?.pageParams?.length < 2
+    ) {
+      fetchNextPage();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasNextPage, isSuccess, fetchNextPage, data]);
+
+  if (!blog) return <LoadingScreen />;
+
+  return (
+    <div className="d-flex flex-fill">
+      <BlogSidebar isPublic={true} />
+      <div className="flex-fill py-16 ps-md-16 d-flex flex-column">
+        <BlogPostList blogId={blog?._id} isPublic={true} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/routes/public-page-error/index.tsx
+++ b/frontend/src/routes/public-page-error/index.tsx
@@ -1,0 +1,35 @@
+import { Button, EmptyScreen, usePaths } from "@edifice-ui/react";
+import { useTranslation } from "react-i18next";
+import { useRouteError } from "react-router-dom";
+
+export default function PublicPageError() {
+  const error = useRouteError();
+  console.error(error);
+
+  const { t } = useTranslation();
+
+  const [imagePath] = usePaths();
+
+  return (
+    <main className="container-fluid d-flex flex-column bg-white">
+      <div className="d-flex flex-column gap-16 align-items-center mt-64">
+        <EmptyScreen
+          imageSrc={`${imagePath}/emptyscreen/illu-error.svg`}
+          imageAlt={t("explorer.emptyScreen.error.alt")}
+          title={t("oops")}
+          text={t("notfound", {
+            ns: "blog",
+          })}
+        />
+        <Button
+          color="primary"
+          onClick={() => {
+            window.location.href = "/blog";
+          }}
+        >
+          {t("back")}
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/routes/public-page-error/index.tsx
+++ b/frontend/src/routes/public-page-error/index.tsx
@@ -1,6 +1,6 @@
 import { Button, EmptyScreen, usePaths } from "@edifice-ui/react";
 import { useTranslation } from "react-i18next";
-import { useRouteError } from "react-router-dom";
+import { useNavigate, useRouteError } from "react-router-dom";
 
 export default function PublicPageError() {
   const error = useRouteError();
@@ -9,6 +9,9 @@ export default function PublicPageError() {
   const { t } = useTranslation();
 
   const [imagePath] = usePaths();
+
+  const navigate = useNavigate();
+  const handleBackClick = () => navigate(-1);
 
   return (
     <main className="container-fluid d-flex flex-column bg-white">
@@ -21,12 +24,7 @@ export default function PublicPageError() {
             ns: "blog",
           })}
         />
-        <Button
-          color="primary"
-          onClick={() => {
-            window.location.href = "/blog";
-          }}
-        >
+        <Button color="primary" onClick={handleBackClick}>
           {t("back")}
         </Button>
       </div>

--- a/frontend/src/routes/public-portal/index.tsx
+++ b/frontend/src/routes/public-portal/index.tsx
@@ -5,7 +5,6 @@ import { QueryClient } from "@tanstack/react-query";
 import { LoaderFunctionArgs, Outlet } from "react-router-dom";
 
 import { blogActions } from "~/config/blogActions";
-import { BlogHeader } from "~/features/Blog/BlogHeader";
 import { useBlogErrorToast } from "~/hooks/useBlogErrorToast";
 import { PostState } from "~/models/post";
 import {
@@ -72,10 +71,5 @@ export function Component() {
 
   if (!blog) return <LoadingScreen />;
 
-  return (
-    <main className="container-fluid d-flex flex-column bg-white">
-      <BlogHeader blog={blog} />
-      <Outlet></Outlet>
-    </main>
-  );
+  return <Outlet></Outlet>;
 }

--- a/frontend/src/routes/public-post-print/index.tsx
+++ b/frontend/src/routes/public-post-print/index.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+
+import { Editor } from "@edifice-ui/editor";
+import { LoadingScreen } from "@edifice-ui/react";
+import { useQuery } from "@tanstack/react-query";
+import { useParams, useRouteLoaderData } from "react-router-dom";
+
+import { PostTitle } from "~/features/Post/PostTitle";
+import { Blog } from "~/models/blog";
+import { publicPostQuery } from "~/services/queries";
+
+export function Component() {
+  const { blog } = useRouteLoaderData("public-portal") as { blog: Blog }; // see public-portal loader
+  const { postId } = useParams();
+  const { data: post } = useQuery(publicPostQuery(blog._id, postId!));
+
+  useEffect(() => {
+    if (blog._id && post) {
+      setTimeout(() => window.print(), 1000);
+    }
+  }, [blog._id, post]);
+
+  if (!blog._id || !post) return <LoadingScreen />;
+
+  return (
+    <>
+      <div className="rounded border pt-16 bg-white">
+        <PostTitle post={post} mode="print" />
+        <div className="mx-32">
+          <Editor content={post.content} mode="read" variant="ghost"></Editor>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/routes/public-post/index.tsx
+++ b/frontend/src/routes/public-post/index.tsx
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+import { useParams, useRouteLoaderData } from "react-router-dom";
+
+import { PostContent } from "~/features/Post/PostContent";
+import { Blog } from "~/models/blog";
+import { publicPostQuery } from "~/services/queries";
+
+export function Component() {
+  const { blog } = useRouteLoaderData("public-portal") as { blog: Blog }; // see public-portal loader
+  const { postId } = useParams();
+  const query = useQuery(publicPostQuery(blog._id, postId!));
+
+  if (!blog || !postId || !query.data) {
+    return <></>;
+  }
+
+  return <PostContent blogId={blog._id} post={query.data} />;
+}

--- a/frontend/src/routes/public-post/index.tsx
+++ b/frontend/src/routes/public-post/index.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useParams, useRouteLoaderData } from "react-router-dom";
 
+import { BlogHeader } from "~/features/Blog/BlogHeader";
 import { PostContent } from "~/features/Post/PostContent";
 import { Blog } from "~/models/blog";
 import { publicPostQuery } from "~/services/queries";
@@ -14,5 +15,10 @@ export function Component() {
     return <></>;
   }
 
-  return <PostContent blogId={blog._id} post={query.data} />;
+  return (
+    <main className="container-fluid d-flex flex-column bg-white">
+      <BlogHeader blog={blog} />
+      <PostContent blogId={blog._id} post={query.data} />
+    </main>
+  );
 }

--- a/frontend/src/services/api/blog.ts
+++ b/frontend/src/services/api/blog.ts
@@ -39,8 +39,11 @@ export function loadPostsList(
   state?: PostState,
   search?: string,
   nbComments: boolean = true,
+  isPublic: boolean = false,
 ) {
-  let path = `/blog/post/list/all/${blogId}?page=${page}&content=true&comments=false&nbComments=${nbComments}`;
+  let path = isPublic
+    ? `/blog/pub/posts/${blogId}?page=${page}&content=true`
+    : `/blog/post/list/all/${blogId}?page=${page}&content=true&comments=false&nbComments=${nbComments}`;
   if (state) {
     path += `&states=${state}`;
   }

--- a/frontend/src/services/api/post.ts
+++ b/frontend/src/services/api/post.ts
@@ -33,6 +33,15 @@ export function loadOriginalPost(blogId: string, post: PostMetadata) {
   );
 }
 
+export async function loadPublicPost(blogId: string, postId: string) {
+  const results = await checkHttpError(
+    odeServices
+      .http()
+      .get<Post[]>(`/blog/pub/posts/${blogId}?postId=${postId}`),
+  );
+  return results[0];
+}
+
 export function deletePost(blogId: string, postId: string) {
   return checkHttpError(
     odeServices.http().delete<void>(`/blog/post/${blogId}/${postId}`),

--- a/frontend/src/services/queries/blog.tsx
+++ b/frontend/src/services/queries/blog.tsx
@@ -23,15 +23,23 @@ import { IActionDefinition } from "~/utils/types";
 export const blogQueryKeys = {
   all: (blogId: string) => ["blog", blogId],
   counter: (blogId: string) => [...blogQueryKeys.all(blogId), "counter"],
-  postsList: (blogId: string, state?: PostState, search?: string) => {
+  postsList: (
+    blogId: string,
+    state?: PostState,
+    search?: string,
+    isPublic?: boolean,
+  ) => {
     const queryKey = [...blogQueryKeys.all(blogId), "postsList"];
     const queryKeyFilter: any = {};
-    if (state || search) {
+    if (state || search || isPublic) {
       if (state) {
         queryKeyFilter.state = state;
       }
       if (search) {
         queryKeyFilter.search = search;
+      }
+      if (isPublic) {
+        queryKeyFilter.isPublic = true;
       }
       queryKey.push(queryKeyFilter);
     }
@@ -69,11 +77,12 @@ export const postsListQuery = (
   state?: PostState,
   search?: string,
   nbComments: boolean = true,
+  isPublic: boolean = false,
 ) => {
   return {
-    queryKey: blogQueryKeys.postsList(blogId, state, search),
+    queryKey: blogQueryKeys.postsList(blogId, state, search, isPublic),
     queryFn: ({ pageParam = 0 }) =>
-      loadPostsList(blogId, pageParam, state, search, nbComments),
+      loadPostsList(blogId, pageParam, state, search, nbComments, isPublic),
     initialPageParam: 0,
     getNextPageParam: (lastPage: any, _allPages: any, lastPageParam: any) => {
       if (
@@ -160,6 +169,7 @@ export const usePostsList = (
   blogId?: string,
   state?: PostState,
   withNbComments: boolean = true,
+  isPublic: boolean = false,
 ) => {
   const params = useParams<{ blogId: string }>();
   const { postsFilters } = usePostsFilter();
@@ -179,6 +189,7 @@ export const usePostsList = (
       state || postsFilters.state,
       postsFilters.search,
       withNbComments,
+      isPublic,
     ),
   );
 

--- a/frontend/src/services/queries/post.tsx
+++ b/frontend/src/services/queries/post.tsx
@@ -9,6 +9,7 @@ import {
   goUpPost,
   publishPost,
   savePost,
+  loadPublicPost,
 } from "../api/post";
 import { Post, PostMetadata, PostState } from "~/models/post";
 
@@ -24,6 +25,14 @@ export const originalPostQuery = (blogId: string, post: PostMetadata) => {
   return {
     queryKey: ["original-post", post._id, post.state],
     queryFn: () => loadOriginalPost(blogId, post),
+  };
+};
+
+/** Query a public post */
+export const publicPostQuery = (blogId: string, postId: string) => {
+  return {
+    queryKey: ["public-post", blogId, postId],
+    queryFn: () => loadPublicPost(blogId, postId),
   };
 };
 


### PR DESCRIPTION
Les blogs public utilisent des endpoints différents, et des rendus sans Layout (sans portal).
Il a fallu adapter les composants et les Query associées, et notamment :

* adapter à React le endpoint (rétro-compatible) pour afficher un blog public,
* adapter à React le endpoint pour imprimer un blog public,
* ajouter un endpoint pour imprimer un billet de blog public,

Ces 2 derniers sont requis car on ouvre la page "print" d'un blog ou d'un billet dans un nouvel onglet, 
ce qui envoie une requête au backend pour charger le index.html. Ce endoint doit donc exister.

* support des routes frontend pour visualiser un blog / détail de billet public
* support des routes frontend pour imprimer un blog / détail de billet public

Ces routes utilisent le `slug` du blog, qui sert de discriminant au loader de React Router pour identifier si on doit charger un blog public ou pas, car les endpoints à interroger sont différents selon le cas.
Aussi, certaines actions sont masquées (exemple : le bouton Imprimer) quand les composants sont en mode "print".

Enfin, ts-client ne supportait plus le mode "utilisateur non-connecté" donc une PR similaire existe là-bas.
C'est un pré-requis pour pouvoir charger un thème CSS pour un utilisateur non-connecté.