### PR TITLE
fix: WB-2688, public blogs views are based on slug

### DIFF
--- a/frontend/src/components/PostPreview/PostPreview.tsx
+++ b/frontend/src/components/PostPreview/PostPreview.tsx
@@ -39,7 +39,7 @@ export const PostPreview = ({ post, index }: PostPreviewProps) => {
   const { t } = useTranslation("blog");
   const navigate = useNavigate();
 
-  const { blog } = useBlog();
+  const { blog, publicView } = useBlog();
   const { contrib, manager, creator } = useActionDefinitions([]);
   const { setActionBarPostId } = useStoreUpdaters();
   const { sidebarHighlightedPost, actionBarPostId } = useBlogState();
@@ -256,6 +256,7 @@ export const PostPreview = ({ post, index }: PostPreviewProps) => {
           post={post}
           blog={blog}
           index={index}
+          publicView={publicView}
         ></PostPreviewActionBar>
       )}
     </>

--- a/frontend/src/components/PostPreview/PostPreviewActionBar.tsx
+++ b/frontend/src/components/PostPreview/PostPreviewActionBar.tsx
@@ -30,12 +30,17 @@ export interface PostPreviewActionBarProps {
    * Index of the post in the list of posts.
    */
   index: number;
+  /**
+   * from a public view ?
+   */
+  publicView?: boolean;
 }
 
 export const PostPreviewActionBar = ({
-  blog: { _id: blogId, slug, visibility },
+  blog: { _id: blogId, slug },
   post,
   index,
+  publicView,
 }: PostPreviewActionBarProps) => {
   // Get available actions and requirements for the post.
   const postActions = usePostActions(postContentActions, blogId, post);
@@ -50,14 +55,12 @@ export const PostPreviewActionBar = ({
   const { setActionBarPostId } = useStoreUpdaters();
   const { actionBarPostId } = useBlogState();
 
-  const isPublic = visibility === "PUBLIC";
-
   const handleEditClick = () => {
     navigate(`/id/${blogId}/post/${post._id}?edit=true`);
   };
 
   const handlePrintClick = () => {
-    if (isPublic) {
+    if (publicView) {
       window.open(`${baseUrl}/pub/${slug}/print/post/${post._id}`, "_blank");
     } else {
       window.open(`${baseUrl}/print/${blogId}/post/${post._id}`, "_blank");
@@ -120,7 +123,7 @@ export const PostPreviewActionBar = ({
         >
           {t("blog.print")}
         </Button>
-        {!isPublic && (
+        {!publicView && (
           <Button
             type="button"
             color="primary"

--- a/frontend/src/features/Blog/BlogPostList.tsx
+++ b/frontend/src/features/Blog/BlogPostList.tsx
@@ -7,31 +7,27 @@ import { PostPreview } from "~/components/PostPreview/PostPreview";
 import { useActionDefinitions } from "~/features/ActionBar/useActionDefinitions";
 import usePostsFilter from "~/hooks/usePostsFilter";
 import { PostState } from "~/models/post";
-import { useBlogCounter, usePostsList } from "~/services/queries";
+import { useBlog, useBlogCounter, usePostsList } from "~/services/queries";
 import { useBlogState } from "~/store";
 
-export interface BlogPostListProps {
-  blogId?: string;
-  isPublic?: boolean;
-}
-
-const BlogPostList = ({ blogId, isPublic }: BlogPostListProps) => {
+const BlogPostList = () => {
   const { t } = useTranslation("blog");
   const [imagePath] = usePaths();
+
+  const { blog, publicView } = useBlog();
 
   const { creator, manager } = useActionDefinitions([]);
   const {
     posts,
     query: { hasNextPage, isFetching, fetchNextPage },
   } = usePostsList(
-    blogId,
-    isPublic ? PostState.PUBLISHED : undefined,
-    isPublic ? false : undefined,
-    isPublic ? true : undefined,
+    blog?._id,
+    publicView ? PostState.PUBLISHED : undefined,
+    publicView ? false : undefined,
   );
 
   const { postsFilters } = usePostsFilter();
-  const { counters } = useBlogCounter(blogId);
+  const { counters } = useBlogCounter(blog?._id);
 
   const { sidebarHighlightedPost } = useBlogState();
 

--- a/frontend/src/features/Blog/BlogSidebar.tsx
+++ b/frontend/src/features/Blog/BlogSidebar.tsx
@@ -7,20 +7,19 @@ import { PostState } from "~/models/post";
 import { useBlog, usePostsList } from "~/services/queries";
 import { useStoreUpdaters } from "~/store";
 
-export interface BlogSidebarProps {
-  state?: PostState;
-}
-
-const BlogSidebar = ({ state }: BlogSidebarProps) => {
+const BlogSidebar = () => {
   const { t } = useTranslation("blog");
 
-  const { blog } = useBlog();
+  const { blog, publicView } = useBlog();
 
-  const isPublic = blog?.visibility === "PUBLIC";
   const {
     posts,
     query: { hasNextPage, isFetching, fetchNextPage },
-  } = usePostsList(blog?._id, state, undefined, isPublic);
+  } = usePostsList(
+    blog?._id,
+    publicView ? PostState.PUBLISHED : undefined,
+    publicView ? false : undefined,
+  );
 
   const { currentApp } = useOdeClient();
 

--- a/frontend/src/features/Post/PostContent.tsx
+++ b/frontend/src/features/Post/PostContent.tsx
@@ -26,7 +26,7 @@ export interface PostContentProps {
 }
 
 export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
-  const { blog } = useBlog();
+  const { blog, publicView } = useBlog();
   // Get available actions and requirements for the post.
   const postActions = usePostActions(postContentActions, blogId, post);
   const { mustSubmit, save, trash, publish, readOnly } = postActions;
@@ -72,7 +72,7 @@ export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
       setMode("edit");
     },
     onPrint: () => {
-      if (blog?.visibility === "PUBLIC") {
+      if (publicView) {
         window.open(
           `${baseUrl}/pub/${blog?.slug}/print/post/${post._id}`,
           "_blank",

--- a/frontend/src/routes/public-blog-print/index.tsx
+++ b/frontend/src/routes/public-blog-print/index.tsx
@@ -14,7 +14,7 @@ export function Component() {
   const {
     posts,
     query: { fetchNextPage, hasNextPage, isSuccess, data },
-  } = usePostsList(blog?._id, PostState.PUBLISHED, false, true);
+  } = usePostsList(blog?._id, PostState.PUBLISHED, false);
 
   useEffect(() => {
     // Load all posts with recurcive fetchNextPage calls.

--- a/frontend/src/routes/public-blog/index.tsx
+++ b/frontend/src/routes/public-blog/index.tsx
@@ -17,7 +17,7 @@ export function Component() {
   // Load all posts with recurcive fetchNextPage calls.
   const {
     query: { fetchNextPage, hasNextPage, isSuccess, data },
-  } = usePostsList(blog?._id, PostState.PUBLISHED, false, true);
+  } = usePostsList(blog?._id, PostState.PUBLISHED, false);
 
   useEffect(() => {
     // Check if the second page of post is not null to set the page size. (not given by the backend)
@@ -45,7 +45,7 @@ export function Component() {
       <div className="d-flex flex-fill">
         <BlogSidebar />
         <div className="flex-fill py-16 ps-md-16 d-flex flex-column">
-          <BlogPostList blogId={blog?._id} isPublic={true} />
+          <BlogPostList />
         </div>
       </div>
     </main>

--- a/frontend/src/routes/public-portal/index.tsx
+++ b/frontend/src/routes/public-portal/index.tsx
@@ -49,7 +49,7 @@ export function Component() {
   // Load all posts with recurcive fetchNextPage calls.
   const {
     query: { fetchNextPage, hasNextPage, isSuccess, data },
-  } = usePostsList(blog?._id, PostState.PUBLISHED, false, true);
+  } = usePostsList(blog?._id, PostState.PUBLISHED, false);
 
   useEffect(() => {
     // Check if the second page of post is not null to set the page size. (not given by the backend)

--- a/frontend/src/services/queries/blog.tsx
+++ b/frontend/src/services/queries/blog.tsx
@@ -136,6 +136,7 @@ export const useBlog = (blogId?: string, slug?: string) => {
   return {
     blog: query.data,
     query,
+    publicView: !!slug,
   };
 };
 
@@ -169,9 +170,8 @@ export const usePostsList = (
   blogId?: string,
   state?: PostState,
   withNbComments: boolean = true,
-  isPublic: boolean = false,
 ) => {
-  const params = useParams<{ blogId: string }>();
+  const params = useParams<{ blogId: string; slug: string }>();
   const { postsFilters } = usePostsFilter();
   const { postPageSize } = useBlogState();
 
@@ -182,6 +182,8 @@ export const usePostsList = (
     blogId = params.blogId;
   }
 
+  const publicView = !!params.slug;
+
   const query = useInfiniteQuery(
     postsListQuery(
       blogId!,
@@ -189,13 +191,14 @@ export const usePostsList = (
       state || postsFilters.state,
       postsFilters.search,
       withNbComments,
-      isPublic,
+      publicView,
     ),
   );
 
   return {
     posts: query.data?.pages.flatMap((page) => page) as Post[],
     query,
+    publicView,
   };
 };
 


### PR DESCRIPTION
Avant le fix, on utilisait la visibilité du blog (PUBLIC ou non) ou sur la présence d'un slug comme discriminants, à différents endroits, et cela provoquait des inconsistences dans le rendu à l'écran ou les appels au backend.