### PR TITLE
fix: #WB-2716, cannot publish an already published post

### DIFF
--- a/frontend/src/features/ActionBar/ActionBarContainer.tsx
+++ b/frontend/src/features/ActionBar/ActionBarContainer.tsx
@@ -3,7 +3,7 @@ import { useTransition, animated } from "@react-spring/web";
 
 export interface ActionBarContainerProps {
   visible: boolean;
-  children: Array<JSX.Element | false>;
+  children: Array<JSX.Element | false | undefined>;
 }
 
 export const ActionBarContainer = ({

--- a/frontend/src/features/Post/PostActionBar.tsx
+++ b/frontend/src/features/Post/PostActionBar.tsx
@@ -1,0 +1,104 @@
+import { Suspense, lazy, useState } from "react";
+
+import { Edit, Options } from "@edifice-ui/icons";
+import { Button, IconButton, useToggle } from "@edifice-ui/react";
+import { useTranslation } from "react-i18next";
+
+import { ActionBarContainer } from "../ActionBar/ActionBarContainer";
+import { PostActions } from "../ActionBar/usePostActions";
+import { Post, PostState } from "~/models/post";
+
+const ConfirmModal = lazy(
+  async () => await import("~/components/ConfirmModal/ConfirmModal"),
+);
+
+export interface PostActionBarProps {
+  post: Post;
+  postActions?: PostActions;
+  isSpeeching?: boolean;
+  onPrint?: () => void;
+  onEdit?: () => void;
+  onPublish?: () => void;
+  onDelete?: () => void;
+}
+
+export const PostActionBar = ({
+  post,
+  postActions,
+  onPrint,
+  onEdit,
+  onPublish,
+  onDelete,
+}: PostActionBarProps) => {
+  const { t } = useTranslation("blog");
+  const { t: common_t } = useTranslation("common");
+  const { mustSubmit, canPublish, isMutating } = postActions || {};
+
+  const [isBarOpen, toggleBar] = useToggle();
+
+  const [confirmDeleteModal, setConfirmDeleteModal] = useState(false);
+
+  return (
+    <>
+      <Button leftIcon={<Edit />} onClick={onEdit}>
+        {common_t("edit")}
+      </Button>
+
+      <IconButton variant="outline" icon={<Options />} onClick={toggleBar} />
+
+      <ActionBarContainer visible={isBarOpen}>
+        {mustSubmit && post.state === PostState.DRAFT && canPublish && (
+          <Button
+            type="button"
+            variant="filled"
+            disabled={isMutating}
+            onClick={onPublish}
+          >
+            {t("blog.submitPost")}
+          </Button>
+        )}
+        {!mustSubmit && post.state !== PostState.PUBLISHED && canPublish && (
+          <Button
+            type="button"
+            variant="filled"
+            disabled={isMutating}
+            onClick={onPublish}
+          >
+            {t("blog.publish")}
+          </Button>
+        )}
+
+        <Button
+          type="button"
+          color="primary"
+          variant="filled"
+          onClick={onPrint}
+        >
+          {t("blog.print")}
+        </Button>
+
+        <Button
+          type="button"
+          color="primary"
+          variant="filled"
+          onClick={() => setConfirmDeleteModal(true)}
+        >
+          {t("blog.delete.post")}
+        </Button>
+      </ActionBarContainer>
+
+      <Suspense>
+        {confirmDeleteModal && (
+          <ConfirmModal
+            id="confirmDeleteModal"
+            isOpen={confirmDeleteModal}
+            header={<>{t("blog.delete.post")}</>}
+            body={<p className="body">{t("confirm.remove.post")}</p>}
+            onSuccess={onDelete}
+            onCancel={() => setConfirmDeleteModal(false)}
+          />
+        )}
+      </Suspense>
+    </>
+  );
+};

--- a/frontend/src/features/Post/PostTitle.tsx
+++ b/frontend/src/features/Post/PostTitle.tsx
@@ -1,30 +1,12 @@
-import { Suspense, lazy, useState } from "react";
-
-import {
-  ArrowLeft,
-  Edit,
-  Options,
-  Print,
-  TextToSpeech,
-} from "@edifice-ui/icons";
-import {
-  Avatar,
-  Button,
-  IconButton,
-  useDate,
-  useToggle,
-} from "@edifice-ui/react";
+import { ArrowLeft, Print, TextToSpeech } from "@edifice-ui/icons";
+import { Avatar, Button, IconButton, useDate } from "@edifice-ui/react";
 import { useTranslation } from "react-i18next";
 
-import { ActionBarContainer } from "../ActionBar/ActionBarContainer";
+import { PostActionBar } from "./PostActionBar";
 import { PostActions } from "../ActionBar/usePostActions";
 import { Post } from "~/models/post";
 import { useBlog } from "~/services/queries";
 import { getAvatarURL, getDatedKey, getUserbookURL } from "~/utils/PostUtils";
-
-const ConfirmModal = lazy(
-  async () => await import("~/components/ConfirmModal/ConfirmModal"),
-);
 
 export interface PostTitleProps {
   post: Post;
@@ -55,10 +37,7 @@ export const PostTitle = ({
   const { t } = useTranslation("blog");
   const { t: common_t } = useTranslation("common");
   const { fromNow } = useDate();
-  const { mustSubmit, readOnly, canPublish } = postActions || {};
-
-  const [confirmDeleteModal, setConfirmDeleteModal] = useState(false);
-  const [isBarOpen, toggleBar] = useToggle();
+  const { readOnly } = postActions || {};
 
   if (mode === "edit") return;
 
@@ -99,45 +78,14 @@ export const PostTitle = ({
                 />
               </>
             ) : (
-              <>
-                <Button leftIcon={<Edit />} onClick={onEdit}>
-                  {common_t("edit")}
-                </Button>
-
-                <IconButton
-                  variant="outline"
-                  icon={<Options />}
-                  onClick={toggleBar}
-                />
-
-                <ActionBarContainer visible={isBarOpen}>
-                  {canPublish ? (
-                    <Button type="button" variant="filled" onClick={onPublish}>
-                      {mustSubmit ? t("blog.submitPost") : t("blog.publish")}
-                    </Button>
-                  ) : (
-                    <></>
-                  )}
-
-                  <Button
-                    type="button"
-                    color="primary"
-                    variant="filled"
-                    onClick={onPrint}
-                  >
-                    {t("blog.print")}
-                  </Button>
-
-                  <Button
-                    type="button"
-                    color="primary"
-                    variant="filled"
-                    onClick={() => setConfirmDeleteModal(true)}
-                  >
-                    {t("blog.delete.post")}
-                  </Button>
-                </ActionBarContainer>
-              </>
+              <PostActionBar
+                post={post}
+                postActions={postActions}
+                onEdit={onEdit}
+                onDelete={onDelete}
+                onPublish={onPublish}
+                onPrint={onPrint}
+              />
             )}
           </div>
         </div>
@@ -164,19 +112,6 @@ export const PostTitle = ({
           </div>
         </div>
       </div>
-
-      <Suspense>
-        {confirmDeleteModal && (
-          <ConfirmModal
-            id="confirmDeleteModal"
-            isOpen={confirmDeleteModal}
-            header={<>{t("blog.delete.post")}</>}
-            body={<p className="body">{t("confirm.remove.post")}</p>}
-            onSuccess={onDelete}
-            onCancel={() => setConfirmDeleteModal(false)}
-          />
-        )}
-      </Suspense>
     </>
   );
 };


### PR DESCRIPTION
Ticket [WB-2716](https://edifice-community.atlassian.net/browse/WB-2716)

Depuis la barre d'action de la page de visualisation d'un billet, on ne doit pas pouvoir :

* soumettre un billet déjà soumis à validation ou déjà publié,
* publier un billet déjà publié,
* modifier/soumettre/publier/remonter un billet déjà en cours de mutation.

Afin d'uniformiser les différentes implémentations des barres d'actions existant dans l'application, celle de la page de visualisation d'un billet a été extraite de `PostTitle` et externalisée dans son propre composant dédié `PostActionBar`.


[WB-2716]: https://edifice-community.atlassian.net/browse/WB-2716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ