### PR TITLE
fix: #WB-2664, display post's state in detailed view

### DIFF
--- a/frontend/src/features/ActionBar/usePostActions.tsx
+++ b/frontend/src/features/ActionBar/usePostActions.tsx
@@ -35,6 +35,8 @@ export interface PostActions {
   goUp: () => Promise<PostMetadata>;
   /** Truthy when a mutation is currently pending on this blog post. */
   isMutating: boolean;
+  /** Truthy when the post's state should be displayed in a badge. */
+  showBadge: boolean;
 }
 
 export const usePostActions = (
@@ -42,8 +44,14 @@ export const usePostActions = (
   blogId: string,
   post: Post,
 ): PostActions => {
-  const { availableActionsForPost, mustSubmit, getDefaultPublishKeyword } =
-    useActionDefinitions(actionDefinitions);
+  const {
+    availableActionsForPost,
+    mustSubmit,
+    getDefaultPublishKeyword,
+    creator,
+    manager,
+    contrib,
+  } = useActionDefinitions(actionDefinitions);
 
   // Memoize a set of expensive computations
   const memoized = useMemo(() => {
@@ -82,6 +90,7 @@ export const usePostActions = (
       deleteMutation.isPending ||
       publishMutation.isPending ||
       goUpMutation.isPending,
+    showBadge: creator || manager || contrib,
     save: (withoutNotification) =>
       saveMutation.mutateAsync({ withoutNotification }),
     trash: () => deleteMutation.mutateAsync(),

--- a/frontend/src/features/Post/PostActionBar.tsx
+++ b/frontend/src/features/Post/PostActionBar.tsx
@@ -49,11 +49,11 @@ export const PostActionBar = ({
   return (
     <>
       {isMainActionEdit ? (
-        <Button leftIcon={<Edit />} onClick={onEdit}>
+        <Button leftIcon={<Edit />} disabled={isMutating} onClick={onEdit}>
           {common_t("edit")}
         </Button>
       ) : (
-        <Button leftIcon={<Send />} onClick={onPublish}>
+        <Button leftIcon={<Send />} disabled={isMutating} onClick={onPublish}>
           {t("blog.publish")}
         </Button>
       )}
@@ -103,6 +103,7 @@ export const PostActionBar = ({
           type="button"
           color="primary"
           variant="filled"
+          disabled={isMutating}
           onClick={() => setConfirmDeleteModal(true)}
         >
           {t("blog.delete.post")}

--- a/frontend/src/features/Post/PostActionBar.tsx
+++ b/frontend/src/features/Post/PostActionBar.tsx
@@ -1,6 +1,6 @@
 import { Suspense, lazy, useState } from "react";
 
-import { Edit, Options } from "@edifice-ui/icons";
+import { Edit, Options, Send } from "@edifice-ui/icons";
 import { Button, IconButton, useToggle } from "@edifice-ui/react";
 import { useTranslation } from "react-i18next";
 
@@ -38,16 +38,30 @@ export const PostActionBar = ({
 
   const [confirmDeleteModal, setConfirmDeleteModal] = useState(false);
 
+  const shouldBeSubmitted =
+    mustSubmit && post.state === PostState.DRAFT && canPublish;
+  const shouldBePublished =
+    !mustSubmit && post.state !== PostState.PUBLISHED && canPublish;
+
+  // Is `edit` the main action ?
+  const isMainActionEdit = !shouldBePublished;
+
   return (
     <>
-      <Button leftIcon={<Edit />} onClick={onEdit}>
-        {common_t("edit")}
-      </Button>
+      {isMainActionEdit ? (
+        <Button leftIcon={<Edit />} onClick={onEdit}>
+          {common_t("edit")}
+        </Button>
+      ) : (
+        <Button leftIcon={<Send />} onClick={onPublish}>
+          {t("blog.publish")}
+        </Button>
+      )}
 
       <IconButton variant="outline" icon={<Options />} onClick={toggleBar} />
 
       <ActionBarContainer visible={isBarOpen}>
-        {mustSubmit && post.state === PostState.DRAFT && canPublish && (
+        {shouldBeSubmitted && (
           <Button
             type="button"
             variant="filled"
@@ -57,7 +71,7 @@ export const PostActionBar = ({
             {t("blog.submitPost")}
           </Button>
         )}
-        {!mustSubmit && post.state !== PostState.PUBLISHED && canPublish && (
+        {isMainActionEdit ? (
           <Button
             type="button"
             variant="filled"
@@ -66,8 +80,16 @@ export const PostActionBar = ({
           >
             {t("blog.publish")}
           </Button>
+        ) : (
+          <Button
+            type="button"
+            variant="filled"
+            disabled={isMutating}
+            onClick={onEdit}
+          >
+            {common_t("edit")}
+          </Button>
         )}
-
         <Button
           type="button"
           color="primary"

--- a/frontend/src/features/Post/PostTitle.tsx
+++ b/frontend/src/features/Post/PostTitle.tsx
@@ -1,10 +1,10 @@
 import { ArrowLeft, Print, TextToSpeech } from "@edifice-ui/icons";
-import { Avatar, Button, IconButton, useDate } from "@edifice-ui/react";
+import { Avatar, Badge, Button, IconButton, useDate } from "@edifice-ui/react";
 import { useTranslation } from "react-i18next";
 
 import { PostActionBar } from "./PostActionBar";
 import { PostActions } from "../ActionBar/usePostActions";
-import { Post } from "~/models/post";
+import { Post, PostState } from "~/models/post";
 import { useBlog } from "~/services/queries";
 import { getAvatarURL, getDatedKey, getUserbookURL } from "~/utils/PostUtils";
 
@@ -92,7 +92,33 @@ export const PostTitle = ({
       )}
 
       <div className="d-flex flex-column mt-8 mx-md-8">
-        <h2 className="text-gray-800">{post.title}</h2>
+        <div className="d-flex align-items-center">
+          <h2 className="text-gray-800">{post.title}</h2>
+          {post.state === PostState.DRAFT && postActions?.showBadge && (
+            <Badge
+              className="ms-16 fs-6"
+              variant={{
+                type: "notification",
+                level: "info",
+                color: "text",
+              }}
+            >
+              {t("draft")}
+            </Badge>
+          )}
+          {post.state === PostState.SUBMITTED && postActions?.showBadge && (
+            <Badge
+              className="blog-post-badge ms-16 fs-6"
+              variant={{
+                type: "notification",
+                level: "warning",
+                color: "text",
+              }}
+            >
+              {t("blog.filters.submitted")}
+            </Badge>
+          )}
+        </div>
         <div className="d-flex align-items-center gap-12 mb-16 mb-md-24 mt-8">
           <Avatar
             alt={t("post.author.avatar")}


### PR DESCRIPTION
Ticket [WB-2664](https://edifice-community.atlassian.net/browse/WB-2664)

In detailed view, 
* badge added, displaying the post state.
* the main action button is now contextual.


[WB-2664]: https://edifice-community.atlassian.net/browse/WB-2664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ