### PR TITLE
feat: #WB-2818, use navigation history to store a stateful value

### DIFF
--- a/frontend/src/features/Post/PostContent.tsx
+++ b/frontend/src/features/Post/PostContent.tsx
@@ -63,7 +63,10 @@ export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
   // Handlers for actions triggered from the post title component.
   const postActionsHandlers = {
     onBackward: () => {
-      navigate(`../..`, { relative: "path" });
+      navigate(`../..`, {
+        relative: "path",
+        state: { defaultFilter: post.state },
+      });
     },
     onDelete: () => {
       trash();

--- a/frontend/src/hooks/usePostsFilter.ts
+++ b/frontend/src/hooks/usePostsFilter.ts
@@ -1,4 +1,4 @@
-import { useSearchParams } from "react-router-dom";
+import { useLocation, useSearchParams } from "react-router-dom";
 
 import { PostState } from "~/models/post";
 import { PostsFilters } from "~/models/postFilter";
@@ -9,8 +9,12 @@ function usePostsFilter(): {
 } {
   const [searchParams, setSearchParams] = useSearchParams();
 
+  // Try to find the default state from the navigation history
+  const location = useLocation();
+  const defaultState = location?.state?.defaultFilter ?? PostState.PUBLISHED;
+
   const postsFilters = {
-    state: (searchParams.get("state") as PostState) || PostState.PUBLISHED,
+    state: (searchParams.get("state") as PostState) || defaultState,
     search: searchParams.get("search") || "",
   };
 


### PR DESCRIPTION
Ticket [WB-2818](https://edifice-community.atlassian.net/browse/WB-2818)

Utilisation de [useNavigate](https://reactrouter.com/en/6.22.3/hooks/use-navigate) pour mémoriser le statut du billet lorsqu’on presse “backward”, et de [useLocation](https://reactrouter.com/en/6.22.3/hooks/use-location) pour retrouver cette valeur au moment de réafficher la liste filtrée de billets.

[WB-2818]: https://edifice-community.atlassian.net/browse/WB-2818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ