### PR TITLE
fix: #WB-2850 get blog in all route before checking rights

### DIFF
--- a/frontend/src/routes/blog-root/index.tsx
+++ b/frontend/src/routes/blog-root/index.tsx
@@ -1,0 +1,18 @@
+import { QueryClient } from "@tanstack/react-query";
+import { LoaderFunctionArgs, Outlet } from "react-router-dom";
+
+import { blogQuery } from "~/services/queries";
+
+export const loader =
+  (queryClient: QueryClient) =>
+  async ({ params }: LoaderFunctionArgs) => {
+    const queryBlog = blogQuery(params.blogId as string);
+
+    await queryClient.fetchQuery(queryBlog);
+
+    return null;
+  };
+
+export function Component() {
+  return <Outlet></Outlet>;
+}

--- a/frontend/src/routes/blog/index.tsx
+++ b/frontend/src/routes/blog/index.tsx
@@ -7,14 +7,12 @@ import { PostState } from "~/models/post";
 import {
   availableActionsQuery,
   blogCounterQuery,
-  blogQuery,
   postsListQuery,
 } from "~/services/queries";
 
 export const loader =
   (queryClient: QueryClient) =>
   async ({ params, request }: LoaderFunctionArgs) => {
-    const queryBlog = blogQuery(params.blogId as string);
     const queryBlogCounter = blogCounterQuery(params.blogId as string);
     const actions = availableActionsQuery(blogActions);
 
@@ -30,7 +28,6 @@ export const loader =
     );
 
     await Promise.all([
-      queryClient.fetchQuery(queryBlog),
       queryClient.fetchInfiniteQuery(queryPostsList),
       queryClient.fetchQuery(queryBlogCounter),
       queryClient.fetchQuery(actions),

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -26,34 +26,47 @@ const routes = (queryClient: QueryClient): RouteObject[] => [
       {
         path: "id/:blogId",
         async lazy() {
-          const { Component, loader } = await import("~/routes/blog");
+          const { Component, loader } = await import("~/routes/blog-root");
           return {
             loader: loader(queryClient),
             Component,
           };
         },
-      },
-      // This page displays a new blank post in edit mode, for a blog.
-      {
-        path: "id/:blogId/post/edit",
-        async lazy() {
-          const { Component, loader } = await import("~/routes/post-edit");
-          return {
-            loader: loader(queryClient),
-            Component,
-          };
-        },
-      },
-      // This page displays an existing post from a blog.
-      {
-        path: "id/:blogId/post/:postId",
-        async lazy() {
-          const { Component, loader } = await import("~/routes/post");
-          return {
-            loader: loader(queryClient),
-            Component,
-          };
-        },
+        children: [
+          // This page displays all information about the blog and its list of posts.
+          {
+            path: "",
+            async lazy() {
+              const { Component, loader } = await import("~/routes/blog");
+              return {
+                loader: loader(queryClient),
+                Component,
+              };
+            },
+          },
+          // This page displays a new blank post in edit mode, for a blog.
+          {
+            path: "post/edit",
+            async lazy() {
+              const { Component, loader } = await import("~/routes/post-edit");
+              return {
+                loader: loader(queryClient),
+                Component,
+              };
+            },
+          },
+          // This page displays an existing post from a blog.
+          {
+            path: "post/:postId",
+            async lazy() {
+              const { Component, loader } = await import("~/routes/post");
+              return {
+                loader: loader(queryClient),
+                Component,
+              };
+            },
+          },
+        ],
       },
     ],
     errorElement: <PageError />,

--- a/frontend/src/routes/post-print/index.tsx
+++ b/frontend/src/routes/post-print/index.tsx
@@ -60,7 +60,7 @@ export function Component() {
 
   return (
     <>
-      <div className="rounded border pt-16 bg-white">
+      <div className="rounded border p-16 bg-white">
         <PostTitle post={post} mode="print" />
         <div className="mx-32">
           <Editor content={post.content} mode="read" variant="ghost"></Editor>


### PR DESCRIPTION
# Description

Issue when checking rights to contrib before getting the blog.
Fix is to have common loader, which load the blog, for all blog routes.

>

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

> PATCH: refactor, internal or non-breaking change which fixes an issue
>
> MINOR: non-breaking change which adds functionality
>
> MAJOR: fix or feature that would cause existing functionality to not work as expected

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
