### PR TITLE
fix: #WB-2655, add function verify content editor + disable button if we can publish or save a post

### DIFF
--- a/frontend/src/components/PostPreview/PostPreviewActionBar.tsx
+++ b/frontend/src/components/PostPreview/PostPreviewActionBar.tsx
@@ -44,8 +44,15 @@ export const PostPreviewActionBar = ({
 }: PostPreviewActionBarProps) => {
   // Get available actions and requirements for the post.
   const postActions = usePostActions(postContentActions, blogId, post);
-  const { mustSubmit, isActionAvailable, goUp, publish, trash, isMutating } =
-    postActions;
+  const {
+    mustSubmit,
+    isActionAvailable,
+    goUp,
+    publish,
+    trash,
+    isMutating,
+    emptyContent,
+  } = postActions;
 
   const { t } = useTranslation("blog");
   const navigate = useNavigate();
@@ -122,7 +129,7 @@ export const PostPreviewActionBar = ({
             <Button
               type="button"
               variant="filled"
-              disabled={isMutating}
+              disabled={isMutating || emptyContent}
               onClick={handlePublishClick}
             >
               {t("blog.publish")}

--- a/frontend/src/components/PostPreview/PostPreviewActionBar.tsx
+++ b/frontend/src/components/PostPreview/PostPreviewActionBar.tsx
@@ -129,7 +129,7 @@ export const PostPreviewActionBar = ({
             <Button
               type="button"
               variant="filled"
-              disabled={isMutating || emptyContent}
+              disabled={isMutating || emptyContent || post.title.length == 0}
               onClick={handlePublishClick}
             >
               {t("blog.publish")}

--- a/frontend/src/features/ActionBar/usePostActions.tsx
+++ b/frontend/src/features/ActionBar/usePostActions.tsx
@@ -10,6 +10,7 @@ import {
   usePublishPost,
   useSavePost,
 } from "~/services/queries";
+import { isEmptyEditorContent } from "~/utils/EditorHasContent";
 import { IActionDefinition } from "~/utils/types";
 
 export interface PostActions {
@@ -37,6 +38,8 @@ export interface PostActions {
   isMutating: boolean;
   /** Truthy when the post's state should be displayed in a badge. */
   showBadge: boolean;
+  /** Truthy if post have editor content */
+  emptyContent: boolean;
 }
 
 export const usePostActions = (
@@ -82,6 +85,8 @@ export const usePostActions = (
   const publishMutation = usePublishPost(blogId);
   const goUpMutation = useGoUpPost(blogId, post._id);
 
+  const emptyContent = isEmptyEditorContent(post.content);
+
   return {
     ...memoized,
     mustSubmit,
@@ -97,5 +102,6 @@ export const usePostActions = (
     publish: () =>
       publishMutation.mutateAsync({ post, publishWith: memoized.publishWith }),
     goUp: () => goUpMutation.mutateAsync(),
+    emptyContent,
   };
 };

--- a/frontend/src/features/ActionBar/usePostActions.tsx
+++ b/frontend/src/features/ActionBar/usePostActions.tsx
@@ -84,8 +84,7 @@ export const usePostActions = (
   const deleteMutation = useDeletePost(blogId, post._id);
   const publishMutation = usePublishPost(blogId);
   const goUpMutation = useGoUpPost(blogId, post._id);
-
-  const emptyContent = isEmptyEditorContent(post.content);
+  const emptyContent = isEmptyEditorContent(post.jsonContent);
 
   return {
     ...memoized,

--- a/frontend/src/features/Post/CreatePost.tsx
+++ b/frontend/src/features/Post/CreatePost.tsx
@@ -46,14 +46,14 @@ export const CreatePost = ({ blogId }: CreatePostProps) => {
   };
 
   const handleSaveClick = async () => {
-    if (blogId || titleRef.current?.value.length !== 0 || !isEmptyContent) {
+    if ((blogId && titleRef.current?.value.length !== 0) || !isEmptyContent) {
       const post = await create();
       if (post) navigate(`/id/${blogId}/post/${post?._id}`);
     }
   };
 
   const handlePublishClick = async () => {
-    if (blogId || (titleRef.current?.value.length == 0 && !isEmptyContent)) {
+    if (blogId && titleRef.current?.value.length !== 0 && !isEmptyContent) {
       const post = await create();
       if (post) {
         await publishMutation.mutate({

--- a/frontend/src/features/Post/CreatePost.tsx
+++ b/frontend/src/features/Post/CreatePost.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 
 import { Editor, EditorRef } from "@edifice-ui/editor";
 import { Save, Send } from "@edifice-ui/icons";
@@ -10,6 +10,7 @@ import { useActionDefinitions } from "../ActionBar/useActionDefinitions";
 import { ButtonGroup } from "~/components/ButtonGroup/ButtonGroup";
 import { TTITLE_LENGTH_MAX } from "~/config/init-config";
 import { useBlog, useCreatePost, usePublishPost } from "~/services/queries";
+import { isEmptyEditorContent } from "~/utils/EditorHasContent";
 
 export interface CreatePostProps {
   blogId: string;
@@ -19,6 +20,8 @@ export const CreatePost = ({ blogId }: CreatePostProps) => {
   const { blog } = useBlog(blogId);
   const editorRef = useRef<EditorRef>(null);
   const titleRef = useRef<HTMLInputElement>(null);
+  const [isEmptyTitle, setIsEmptyTitle] = useState<string>("");
+  const [isEmptyContent, setIsEmptyContent] = useState<boolean>(false);
   const { t } = useTranslation("blog");
 
   const navigate = useNavigate();
@@ -33,8 +36,8 @@ export const CreatePost = ({ blogId }: CreatePostProps) => {
 
   const create = async () => {
     const content = editorRef.current?.getContent("html") as string;
-    const title = titleRef.current?.value;
-    if (!blogId || !title || title.trim().length == 0 || !content) return;
+    const title = titleRef.current?.value ?? "";
+    if (!content) return;
     return await createMutation.mutateAsync({ title, content });
   };
 
@@ -43,19 +46,36 @@ export const CreatePost = ({ blogId }: CreatePostProps) => {
   };
 
   const handleSaveClick = async () => {
-    const post = await create();
-    if (post) navigate(`/id/${blog?._id}/post/${post?._id}`);
+    if (
+      blogId ||
+      titleRef.current?.value.trim().length !== 0 ||
+      !isEmptyContent
+    ) {
+      const post = await create();
+      if (post) navigate(`/id/${blogId}/post/${post?._id}`);
+    }
   };
 
   const handlePublishClick = async () => {
-    const post = await create();
-    if (post) {
-      await publishMutation.mutate({
-        post,
-        publishWith: getDefaultPublishKeyword(post.author.userId),
-      });
-      navigate(`/id/${blog?._id}/post/${post?._id}`);
+    if (
+      blogId ||
+      titleRef.current?.value.trim().length == 0 ||
+      !isEmptyContent
+    ) {
+      const post = await create();
+      if (post) {
+        await publishMutation.mutate({
+          post,
+          publishWith: getDefaultPublishKeyword(post.author.userId),
+        });
+        navigate(`/id/${blogId}/post/${post?._id}`);
+      }
     }
+  };
+
+  const handleContentChange = (content: string) => {
+    const emptyContent = isEmptyEditorContent(content);
+    setIsEmptyContent(emptyContent);
   };
 
   return (
@@ -68,6 +88,7 @@ export const CreatePost = ({ blogId }: CreatePostProps) => {
           size="md"
           placeholder={t("post.title.placeholder")}
           maxLength={TTITLE_LENGTH_MAX}
+          onChange={(e) => setIsEmptyTitle(e.target.value)}
         ></Input>
       </FormControl>
       <FormControl id="postContent" className="mt-16 mx-md-16">
@@ -79,6 +100,7 @@ export const CreatePost = ({ blogId }: CreatePostProps) => {
           content=""
           mode="edit"
           visibility={blog?.visibility === "PUBLIC" ? "public" : "protected"}
+          onContentChange={handleContentChange}
         ></Editor>
       </div>
       <ButtonGroup className="gap-8 mt-16 mx-md-16" variant="reverse">
@@ -89,7 +111,9 @@ export const CreatePost = ({ blogId }: CreatePostProps) => {
           type="button"
           variant="outline"
           leftIcon={<Save />}
-          disabled={disableButtons}
+          disabled={
+            disableButtons || (isEmptyContent && isEmptyTitle.length == 0)
+          }
           onClick={handleSaveClick}
         >
           {t("blog.save")}
@@ -97,7 +121,9 @@ export const CreatePost = ({ blogId }: CreatePostProps) => {
         <Button
           type="button"
           leftIcon={<Send />}
-          disabled={disableButtons}
+          disabled={
+            isEmptyTitle.length == 0 || isEmptyContent || disableButtons
+          }
           onClick={handlePublishClick}
         >
           {mustSubmit ? t("blog.submitPost") : t("blog.publish")}

--- a/frontend/src/features/Post/CreatePost.tsx
+++ b/frontend/src/features/Post/CreatePost.tsx
@@ -73,7 +73,8 @@ export const CreatePost = ({ blogId }: CreatePostProps) => {
     }
   };
 
-  const handleContentChange = (content: string) => {
+  const handleContentChange = ({ editor }: { editor: any }) => {
+    const content = editor?.getHTML();
     const emptyContent = isEmptyEditorContent(content);
     setIsEmptyContent(emptyContent);
   };

--- a/frontend/src/features/Post/CreatePost.tsx
+++ b/frontend/src/features/Post/CreatePost.tsx
@@ -46,22 +46,14 @@ export const CreatePost = ({ blogId }: CreatePostProps) => {
   };
 
   const handleSaveClick = async () => {
-    if (
-      blogId ||
-      titleRef.current?.value.trim().length !== 0 ||
-      !isEmptyContent
-    ) {
+    if (blogId || titleRef.current?.value.length !== 0 || !isEmptyContent) {
       const post = await create();
       if (post) navigate(`/id/${blogId}/post/${post?._id}`);
     }
   };
 
   const handlePublishClick = async () => {
-    if (
-      blogId ||
-      titleRef.current?.value.trim().length == 0 ||
-      !isEmptyContent
-    ) {
+    if (blogId || (titleRef.current?.value.length == 0 && !isEmptyContent)) {
       const post = await create();
       if (post) {
         await publishMutation.mutate({
@@ -74,7 +66,7 @@ export const CreatePost = ({ blogId }: CreatePostProps) => {
   };
 
   const handleContentChange = ({ editor }: { editor: any }) => {
-    const content = editor?.getHTML();
+    const content = editor?.getJSON();
     const emptyContent = isEmptyEditorContent(content);
     setIsEmptyContent(emptyContent);
   };
@@ -123,7 +115,7 @@ export const CreatePost = ({ blogId }: CreatePostProps) => {
           type="button"
           leftIcon={<Send />}
           disabled={
-            isEmptyTitle.length == 0 || isEmptyContent || disableButtons
+            isEmptyTitle.trim().length == 0 || isEmptyContent || disableButtons
           }
           onClick={handlePublishClick}
         >

--- a/frontend/src/features/Post/PostActionBar.tsx
+++ b/frontend/src/features/Post/PostActionBar.tsx
@@ -56,7 +56,7 @@ export const PostActionBar = ({
       ) : (
         <Button
           leftIcon={<Send />}
-          disabled={isMutating || emptyContent}
+          disabled={isMutating || emptyContent || post.title.length == 0}
           onClick={onPublish}
         >
           {t("blog.publish")}
@@ -81,7 +81,7 @@ export const PostActionBar = ({
             <Button
               type="button"
               variant="filled"
-              disabled={isMutating || emptyContent}
+              disabled={isMutating || emptyContent || post.title.length == 0}
               onClick={onPublish}
             >
               {t("blog.publish")}

--- a/frontend/src/features/Post/PostActionBar.tsx
+++ b/frontend/src/features/Post/PostActionBar.tsx
@@ -32,7 +32,8 @@ export const PostActionBar = ({
 }: PostActionBarProps) => {
   const { t } = useTranslation("blog");
   const { t: common_t } = useTranslation("common");
-  const { mustSubmit, canPublish, isMutating } = postActions || {};
+  const { mustSubmit, canPublish, isMutating, emptyContent } =
+    postActions || {};
 
   const [isBarOpen, toggleBar] = useToggle();
 
@@ -53,7 +54,11 @@ export const PostActionBar = ({
           {common_t("edit")}
         </Button>
       ) : (
-        <Button leftIcon={<Send />} disabled={isMutating} onClick={onPublish}>
+        <Button
+          leftIcon={<Send />}
+          disabled={isMutating || emptyContent}
+          onClick={onPublish}
+        >
           {t("blog.publish")}
         </Button>
       )}
@@ -76,7 +81,7 @@ export const PostActionBar = ({
             <Button
               type="button"
               variant="filled"
-              disabled={isMutating}
+              disabled={isMutating || emptyContent}
               onClick={onPublish}
             >
               {t("blog.publish")}

--- a/frontend/src/features/Post/PostContent.tsx
+++ b/frontend/src/features/Post/PostContent.tsx
@@ -123,7 +123,8 @@ export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
     setMode("read");
   };
 
-  const handleContentChange = (content: string) => {
+  const handleContentChange = ({ editor }: { editor: any }) => {
+    const content = editor?.getHTML();
     const emptyContent = isEmptyEditorContent(content);
     setIsEmptyContent(emptyContent);
   };

--- a/frontend/src/features/Post/PostContent.tsx
+++ b/frontend/src/features/Post/PostContent.tsx
@@ -104,9 +104,11 @@ export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
   // Save modifications
   const handleSaveClick = () => {
     const contentHtml = editorRef.current?.getContent("html") as string;
-    if (post || !isEmptyContent || !title) {
+    const contentJson = editorRef.current?.getContent("json") as JSON;
+    if (post || (!isEmptyContent && !title)) {
       post.title = title;
       post.content = contentHtml;
+      post.jsonContent = contentJson;
       save();
       setMode("read");
     }
@@ -124,7 +126,7 @@ export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
   };
 
   const handleContentChange = ({ editor }: { editor: any }) => {
-    const content = editor?.getHTML();
+    const content = editor?.getJSON();
     const emptyContent = isEmptyEditorContent(content);
     setIsEmptyContent(emptyContent);
   };

--- a/frontend/src/features/Post/PostContent.tsx
+++ b/frontend/src/features/Post/PostContent.tsx
@@ -105,7 +105,7 @@ export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
   const handleSaveClick = () => {
     const contentHtml = editorRef.current?.getContent("html") as string;
     const contentJson = editorRef.current?.getContent("json") as JSON;
-    if (post || (!isEmptyContent && !title)) {
+    if (post && (!isEmptyContent || title.length !== 0)) {
       post.title = title;
       post.content = contentHtml;
       post.jsonContent = contentJson;

--- a/frontend/src/utils/EditorHasContent.ts
+++ b/frontend/src/utils/EditorHasContent.ts
@@ -1,10 +1,10 @@
-export const isEmptyEditorContent = (content: string) => {
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(content, "text/html");
-
-  const containsMedia = doc.querySelector("img, video, audio, iframe") !== null;
-
-  const hasTextContent = doc?.body?.textContent?.trim() !== "";
-
-  return !hasTextContent && !containsMedia;
+export const isEmptyEditorContent = (json: any) => {
+  if (
+    Array.isArray(json.content) &&
+    json.content.length === 1 &&
+    !Object.prototype.hasOwnProperty.call(json.content[0], "content")
+  ) {
+    return true;
+  }
+  return false;
 };

--- a/frontend/src/utils/EditorHasContent.ts
+++ b/frontend/src/utils/EditorHasContent.ts
@@ -1,0 +1,10 @@
+export const isEmptyEditorContent = (content: string) => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(content, "text/html");
+
+  const containsMedia = doc.querySelector("img, video, audio, iframe") !== null;
+
+  const hasTextContent = doc?.body?.textContent?.trim() !== "";
+
+  return !hasTextContent && !containsMedia;
+};


### PR DESCRIPTION
Description : 

Ajout d'une fonction afin de vérifier si il y a du contenu dans l'éditeur. Obliger de faire cette vérification car sinon l'éditeur vide nous renvoie toujours un html `<p></p>`.

Ajout d'un boolean qui disable le bouton pour publier un post lorsque il n'y a rien dans l'éditeur + dans le titre.
Ajout d'un boolean qui disable le bouton enregistrer quand il n'y a rien de rempli mais reste activé lorsqu'il y a au moins un titre ou un contenu. 

Ajout d'un callback dans Editor pour écouter en direct si le content est rempli ou non, voir cette PR : https://github.com/edificeio/edifice-ui/pull/139

Tikcet : https://edifice-community.atlassian.net/browse/WB-2655