### PR TITLE
fix: #WB-2793, add aria-labels where missing

### DIFF
--- a/frontend/src/features/Blog/BlogActionBar.tsx
+++ b/frontend/src/features/Blog/BlogActionBar.tsx
@@ -166,6 +166,7 @@ export const BlogActionBar = ({ blog }: BlogActionBarProps) => {
           color="primary"
           variant="outline"
           icon={<Options />}
+          aria-label={common_t("tiptap.tooltip.plus")}
           onClick={handleOpenMenuClick}
         />
 

--- a/frontend/src/features/Blog/BlogHeader.tsx
+++ b/frontend/src/features/Blog/BlogHeader.tsx
@@ -1,8 +1,7 @@
-import { AppHeader, Breadcrumb } from "@edifice-ui/react";
+import { AppHeader, Breadcrumb, useOdeClient } from "@edifice-ui/react";
 
 import { BlogActionBar } from "./BlogActionBar";
 import { Blog } from "~/models/blog";
-import { basename } from "~/routes";
 
 export interface BlogProps {
   blog: Blog;
@@ -10,22 +9,12 @@ export interface BlogProps {
 }
 
 export const BlogHeader = ({ blog, readonly = false }: BlogProps) => {
+  const { currentApp } = useOdeClient();
   return (
     <AppHeader>
       <div className="d-flex flex-column flex-md-row flex-nowrap justify-content-md-between flex-fill gap-12 overflow-hidden">
         <div className="overflow-hidden">
-          <Breadcrumb
-            app={{
-              address: basename,
-              display: false,
-              displayName: "Blog",
-              icon: "",
-              isExternal: false,
-              name: "",
-              scope: [],
-            }}
-            name={blog.title}
-          />
+          {currentApp && <Breadcrumb app={currentApp} name={blog.title} />}
         </div>
         {!readonly && <BlogActionBar blog={blog} />}
       </div>

--- a/frontend/src/features/Post/PostActionBar.tsx
+++ b/frontend/src/features/Post/PostActionBar.tsx
@@ -65,7 +65,12 @@ export const PostActionBar = ({
         </Button>
       )}
 
-      <IconButton variant="outline" icon={<Options />} onClick={toggleBar} />
+      <IconButton
+        variant="outline"
+        icon={<Options />}
+        aria-label={common_t("tiptap.tooltip.plus")}
+        onClick={toggleBar}
+      />
 
       <ActionBarContainer visible={isBarOpen}>
         {shouldBeSubmitted && (


### PR DESCRIPTION
* Ajout de aria-labels sur les boutons "..." qui permettent d'afficher la barre d'action (pour les blogs et les billets)
* Uniformisation des Breadcrumb entre les pages blog et billet : suppression d'un bout de code qui s'activait en local uniquement (pratique, mais pas utile en prod)