### PR TITLE
fix: #WB-3068, better UX when saving a post without having a network connection

### DIFF
--- a/frontend/src/features/ActionBar/usePostActions.tsx
+++ b/frontend/src/features/ActionBar/usePostActions.tsx
@@ -26,12 +26,18 @@ export interface PostActions {
    * @param action - The action to check
    */
   isActionAvailable: (action: ActionType) => boolean;
-  /** Action to save a post as draft; invalidates cached queries if needed. */
+  /**
+   * Action to save a post as draft; invalidates cached queries if needed.
+   * @param withoutNotification truthy to disable the "success" notification toast
+   */
   save: (withoutNotification?: boolean) => Promise<PostMetadata>;
   /** Action to delete a post; invalidates cached queries if needed. */
   trash: () => Promise<void>;
-  /** Action to publish or submit a post; invalidates cached queries if needed. */
-  publish: () => Promise<Post>;
+  /**
+   * Action to publish or submit a post; invalidates cached queries if needed.
+   * @param fromEditor set to true if editor is opened when submitting.
+   */
+  publish: (fromEditor?: boolean) => Promise<Post>;
   /** Action to move up a post; invalidates cached queries if needed. */
   goUp: () => Promise<PostMetadata>;
   /** Truthy when a mutation is currently pending on this blog post. */
@@ -101,8 +107,12 @@ export const usePostActions = (
     save: (withoutNotification) =>
       saveMutation.mutateAsync({ withoutNotification }),
     trash: () => deleteMutation.mutateAsync(),
-    publish: () =>
-      publishMutation.mutateAsync({ post, publishWith: memoized.publishWith }),
+    publish: (fromEditor?: boolean) =>
+      publishMutation.mutateAsync({
+        post,
+        publishWith: memoized.publishWith,
+        fromEditor,
+      }),
     goUp: () => goUpMutation.mutateAsync(),
     emptyContent,
   };

--- a/frontend/src/features/Post/CreatePost.tsx
+++ b/frontend/src/features/Post/CreatePost.tsx
@@ -59,6 +59,7 @@ export const CreatePost = ({ blogId }: CreatePostProps) => {
         await publishMutation.mutate({
           post,
           publishWith: getDefaultPublishKeyword(post.author.userId),
+          fromEditor: true,
         });
         navigate(`/id/${blogId}/post/${post?._id}`);
       }
@@ -89,6 +90,7 @@ export const CreatePost = ({ blogId }: CreatePostProps) => {
       </FormControl>
       <div className="mx-md-16 post-content-editor">
         <Editor
+          id="postContent"
           ref={editorRef}
           content=""
           mode="edit"

--- a/frontend/src/features/Post/PostContent.tsx
+++ b/frontend/src/features/Post/PostContent.tsx
@@ -2,7 +2,14 @@ import { Suspense, useEffect, useRef, useState } from "react";
 
 import { Editor, EditorRef } from "@edifice-ui/editor";
 import { Save, Send } from "@edifice-ui/icons";
-import { Alert, Button, FormControl, Input, Label } from "@edifice-ui/react";
+import {
+  Alert,
+  Button,
+  FormControl,
+  Input,
+  Label,
+  Loading,
+} from "@edifice-ui/react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
@@ -128,7 +135,7 @@ export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
     post.title = title;
     post.content = contentHtml;
     await save(true);
-    await publish();
+    await publish(true);
     setMode("read");
   };
 
@@ -213,7 +220,7 @@ export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
               <Button
                 type="button"
                 variant="outline"
-                leftIcon={<Save />}
+                leftIcon={isMutating ? <Loading isLoading={true} /> : <Save />}
                 disabled={isMutating || (isEmptyContent && title.length == 0)}
                 onClick={handleSaveClick}
               >
@@ -222,7 +229,7 @@ export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
             )}
             <Button
               type="button"
-              leftIcon={<Send />}
+              leftIcon={isMutating ? <Loading isLoading={true} /> : <Send />}
               disabled={isMutating || title.length == 0 || isEmptyContent}
               onClick={handlePublishClick}
             >

--- a/frontend/src/services/api/post.ts
+++ b/frontend/src/services/api/post.ts
@@ -57,10 +57,16 @@ export function deletePost(blogId: string, postId: string) {
 export function savePost(blogId: string, post: Post) {
   const { _id: postId, title, content } = post;
   return checkHttpError(
-    odeServices.http().putJson<PostMetadata>(`/blog/post/${blogId}/${postId}`, {
-      title,
-      content,
-    }),
+    odeServices.http().putJson<PostMetadata>(
+      `/blog/post/${blogId}/${postId}`,
+      {
+        title,
+        content,
+      },
+      // Do not emit any notification that is catched+shown by the MediaLibrary.
+      // The Post component has its own notification channel instead.
+      { disableNotifications: true },
+    ),
   );
 }
 
@@ -76,12 +82,17 @@ export function publishPost(
   blogId: string,
   post: Post,
   publishWith: "publish" | "submit",
+  fromEditor?: boolean,
 ) {
   const { _id: postId } = post;
   return checkHttpError(
-    odeServices
-      .http()
-      .putJson<Post>(`/blog/post/${publishWith}/${blogId}/${postId}`, {}),
+    odeServices.http().putJson<Post>(
+      `/blog/post/${publishWith}/${blogId}/${postId}`,
+      {},
+      // Do not emit any notification that is catched+shown by the MediaLibrary.
+      // The Post component has its own notification channel instead.
+      { disableNotifications: fromEditor },
+    ),
   );
 }
 

--- a/frontend/src/services/queries/post.tsx
+++ b/frontend/src/services/queries/post.tsx
@@ -163,10 +163,12 @@ export const usePublishPost = (blogId: string) => {
     mutationFn: ({
       post,
       publishWith = "publish",
+      fromEditor,
     }: {
       post: Post;
       publishWith?: "publish" | "submit";
-    }) => publishPost(blogId, post, publishWith),
+      fromEditor?: boolean;
+    }) => publishPost(blogId, post, publishWith, fromEditor),
     onSuccess: (result, { post, publishWith }) => {
       // Publishing/submitting a post change its state. Update the query data accordingly.
       // Use the state which is sent back, or guess it from the publish/submit mess.

--- a/frontend/src/utils/BlogEvent.ts
+++ b/frontend/src/utils/BlogEvent.ts
@@ -25,24 +25,61 @@ export async function checkHttpError<T>(promise: Promise<T>) {
   // odeServices.http() methods return never-failing promises.
   // It is the responsability of the application to check for them.
   const result = await promise;
-  if (!odeServices.http().isResponseError()) return result;
+  const isResponseHTML =
+    (
+      odeServices.http().latestResponse.headers?.get("Content-Type") as
+        | string
+        | undefined
+    )?.includes?.("html") ?? false;
 
-  notifyError({
-    code: ERROR_CODE.TRANSPORT_ERROR,
-    text: odeServices.http().latestResponse.statusText,
-  });
+  // Check if request was redirected to login page (content is not JSON) or an error occured
+  if (!isResponseHTML && !odeServices.http().isResponseError()) return result;
 
-  if (
-    odeServices.http().latestResponse.headers.get("content-type") !==
-    "application/json"
-  ) {
-    throw new Error(
-      odeServices.http().latestResponse.status === 401
-        ? "Unauthorized"
-        : "Error " + odeServices.http().latestResponse.status,
-    );
-  }
+  // Map well-known status/text to i18n key
+  const blogError = odeServices.http().isResponseError()
+    ? getLatestError()
+    : {
+        code: ERROR_CODE.NOT_LOGGED_IN,
+        text: "disconnected.warning",
+      };
+
+  // Display an error toast
+  notifyError(blogError);
 
   // Throw an error here. React Query will use it effectively.
-  throw odeServices.http().latestResponse.statusText;
+  throw new Error(blogError.text);
+}
+
+/*  */
+function getLatestError() {
+  let code: ErrorCode = ERROR_CODE.TRANSPORT_ERROR,
+    text = odeServices.http().latestResponse.statusText;
+
+  switch (odeServices.http().latestResponse.status) {
+    case 401:
+      code = ERROR_CODE.TRANSPORT_ERROR;
+      text = "e401.page";
+      break;
+    case 403:
+      code = ERROR_CODE.MALFORMED_DATA;
+      text = "e403";
+      break;
+    case 404:
+      code = ERROR_CODE.TRANSPORT_ERROR;
+      text = "e404.page";
+      break;
+    case 408:
+      code = ERROR_CODE.TIME_OUT;
+      text = "e408";
+      break;
+    case 500:
+      code = ERROR_CODE.UNKNOWN;
+      text = "e500";
+      break;
+  }
+
+  return {
+    code,
+    text,
+  };
 }


### PR DESCRIPTION
# Description

> [Ticket WB-3068](https://edifice-community.atlassian.net/browse/WB-3068)

* Disabled buttons are showing a `<Loading/>` while mutating
* Better i18n for error toasts

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

> PATCH: refactor, internal or non-breaking change which fixes an issue
>
> MINOR: non-breaking change which adds functionality
>
> MAJOR: fix or feature that would cause existing functionality to not work as expected

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
