### PR TITLE
fix: #WB-1357, allow access to public pages

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -22,8 +22,19 @@ const queryClient = new QueryClient({
   queryCache: new QueryCache({
     onError: (error) => {
       if (typeof error === "string") {
-        if (error === ERROR_CODE.NOT_LOGGED_IN)
-          window.location.replace("/auth/login");
+        if (error === ERROR_CODE.NOT_LOGGED_IN) {
+          // Dispatch an event and let public pages preventDefault() it
+          // => see `disableLoginPageRedirection` utility function
+          if (
+            rootElement?.dispatchEvent(
+              new CustomEvent<string>(ERROR_CODE.NOT_LOGGED_IN, {
+                cancelable: true,
+              }),
+            )
+          ) {
+            window.location.replace("/auth/login");
+          }
+        }
       }
     },
   }),

--- a/frontend/src/routes/public-portal/index.tsx
+++ b/frontend/src/routes/public-portal/index.tsx
@@ -6,21 +6,24 @@ import { blogActions } from "~/config/blogActions";
 import { useBlogErrorToast } from "~/hooks/useBlogErrorToast";
 import { Blog } from "~/models/blog";
 import { availableActionsQuery, blogPublicQuery } from "~/services/queries";
+import { disableLoginPageRedirection } from "~/utils/disableLoginPageRedirection";
 
 export const loader =
   (queryClient: QueryClient) =>
-  async ({ params }: LoaderFunctionArgs) => {
-    const { slug } = params;
-    const queryBlogPublic = blogPublicQuery(slug as string);
-    const blog = await queryClient.fetchQuery(queryBlogPublic);
-    if (!blog._id) throw "Unexpected error";
+  ({ params }: LoaderFunctionArgs) =>
+    /* /!\ Public portal must disable login page redirection /!\ */
+    disableLoginPageRedirection(async () => {
+      const { slug } = params;
+      const queryBlogPublic = blogPublicQuery(slug as string);
+      const blog = await queryClient.fetchQuery(queryBlogPublic);
+      if (!blog._id) throw "Unexpected error";
 
-    const actions = availableActionsQuery(blogActions);
+      const actions = availableActionsQuery(blogActions);
 
-    await Promise.all([queryClient.fetchQuery(actions)]);
+      await Promise.all([queryClient.fetchQuery(actions)]);
 
-    return { blog };
-  };
+      return { blog };
+    });
 
 export function Component() {
   const { blog } = useLoaderData() as { blog: Blog };

--- a/frontend/src/utils/disableLoginPageRedirection.ts
+++ b/frontend/src/utils/disableLoginPageRedirection.ts
@@ -1,0 +1,31 @@
+import { ERROR_CODE } from "edifice-ts-client";
+
+/**
+ * This function wraps a loader for ReactRouter,
+ * preventing redirections to the login page.
+ *
+ * It should be used on public pages only.
+ */
+export async function disableLoginPageRedirection<T>(
+  lazyLoaderFunction: () => Promise<T>,
+) {
+  const rootElement = document.getElementById("root");
+
+  const preventRedirecting = (event: Event) => {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  };
+
+  // Add a dedicated event listener.
+  rootElement?.addEventListener(ERROR_CODE.NOT_LOGGED_IN, preventRedirecting);
+
+  const result = await lazyLoaderFunction();
+
+  // Route loaded, remove the dedicated event listener
+  rootElement?.removeEventListener(
+    ERROR_CODE.NOT_LOGGED_IN,
+    preventRedirecting,
+  );
+
+  return result;
+}


### PR DESCRIPTION
# Description

Getting the user session always throws a NOT_LOGGED_IN exception for disconnected users,
so application with public pages must "catch" and bypass it.

* Catching is done in react router error management, 
* it then launches an event so that public pages can "preventDefault" on it.

* The public-page lazy loader has put a listener for this event.
* and prevents its default (the redirection) => page loading can complete.

> Ticket WB-3157

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

> PATCH: refactor, internal or non-breaking change which fixes an issue
>
> MINOR: non-breaking change which adds functionality
>
> MAJOR: fix or feature that would cause existing functionality to not work as expected

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
