### PR TITLE
fix: #WB-3139, change button label when a manager saves a submitted post

### DIFF
--- a/frontend/src/features/ActionBar/usePostActions.tsx
+++ b/frontend/src/features/ActionBar/usePostActions.tsx
@@ -47,8 +47,10 @@ export interface PostActions {
   showBadge: boolean;
   /** Truthy when the views counter should be displayed. */
   showViews: boolean;
-  /** WB-2886 Thruthy when the save (as draft) button should be hidden. */
-  hideSaveDraft: boolean;
+  /** WB-3139 i18n key to save (or save as draft) button. */
+  saveButtonI18nKey: string;
+  /** WB-2886 Truthy when the save (as draft) button should be hidden. */
+  hideSaveButton: boolean;
   /** Truthy if post have editor content */
   emptyContent: boolean;
 }
@@ -112,7 +114,7 @@ export const usePostActions = (
     showBadge: creator || manager || contrib,
     showViews: creator || manager,
     /* WB-3071 */
-    hideSaveDraft:
+    hideSaveButton:
       /* Circuit actif : un contributeur n'a pas le droit de mettre en brouillon
          un billet publié dont il est l’auteur.
          (car il n’a pas le droit de le publier seul),
@@ -138,6 +140,16 @@ export const usePostActions = (
         (manager || creator || contrib) &&
         post.state === PostState.PUBLISHED &&
         post.author.userId !== user?.userId),
+    /* WB-3139 */
+    /* Un billet soumis à validation, modifié par un gestionnaire qui n'en est pas l'auteur, ne change pas d'état.
+       Le bouton doit alors indiquer "Enregistrer" et non pas "Brouillon". */
+    saveButtonI18nKey:
+      isRestraint &&
+      (manager || creator) &&
+      post.state === PostState.SUBMITTED &&
+      post.author.userId !== user?.userId
+        ? "blog.save"
+        : "draft.save",
     save: (withoutNotification) =>
       saveMutation.mutateAsync({ withoutNotification }),
     trash: () => deleteMutation.mutateAsync(),

--- a/frontend/src/features/Post/PostContent.tsx
+++ b/frontend/src/features/Post/PostContent.tsx
@@ -46,7 +46,8 @@ export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
     publish,
     readOnly,
     isMutating,
-    hideSaveDraft,
+    saveButtonI18nKey,
+    hideSaveButton,
     showViews,
   } = postActions;
 
@@ -215,12 +216,12 @@ export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
           >
             <Button
               type="button"
-              variant={hideSaveDraft ? "outline" : "ghost"}
+              variant={hideSaveButton ? "outline" : "ghost"}
               onClick={handleCancelClick}
             >
               {t("cancel")}
             </Button>
-            {!hideSaveDraft && (
+            {!hideSaveButton && (
               <Button
                 type="button"
                 variant="outline"
@@ -228,7 +229,7 @@ export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
                 disabled={isMutating || (isEmptyContent && title.length == 0)}
                 onClick={handleSaveClick}
               >
-                {t("draft.save")}
+                {t(saveButtonI18nKey)}
               </Button>
             )}
             <Button


### PR DESCRIPTION

# Description

As a manager, the save button label was not correct while modifying a post submitted by a contributor.

> [Ticket WB-3139](https://edifice-community.atlassian.net/browse/WB-3139)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

> PATCH: refactor, internal or non-breaking change which fixes an issue
>
> MINOR: non-breaking change which adds functionality
>
> MAJOR: fix or feature that would cause existing functionality to not work as expected

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
