### PR TITLE
fix: WB-3020, memoize updated content and title, and reset them on cancellation

### DIFF
--- a/frontend/src/features/Post/PostContent.tsx
+++ b/frontend/src/features/Post/PostContent.tsx
@@ -114,8 +114,9 @@ export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
   // Cancel modifications
   const handleCancelClick = () => {
     setMode("read");
-    // Restore previous content
+    // Restore previous content and title
     setContent(post?.content ?? "");
+    setTitle(post?.title ?? "");
   };
 
   // Save modifications
@@ -144,6 +145,7 @@ export const PostContent = ({ blogId, post, comments }: PostContentProps) => {
 
   const handleContentChange = ({ editor }: { editor: any }) => {
     const content = editor?.getJSON();
+    setContent(content);
     const emptyContent = isEmptyEditorContent(content);
     setIsEmptyContent(emptyContent);
   };


### PR DESCRIPTION
# Description

Le titre et le contenu d'un billet doivent être réinitialisés lorsque l'utilisateur annule sa saisie.
L'implémentation précédente ne gérait pas le titre, et ne détectait pas que le contenu avait changé : du coup, un `useEffect` dépendant du `content` ne se déclenchait pas et le contenu restait inchangé.

[Va de pair avec cette autre PR.](https://github.com/edificeio/edifice-ui/pull/255)

> [Ticket WB-3020](https://edifice-community.atlassian.net/browse/WB-3020)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

> PATCH: refactor, internal or non-breaking change which fixes an issue
>
> MINOR: non-breaking change which adds functionality
>
> MAJOR: fix or feature that would cause existing functionality to not work as expected

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
